### PR TITLE
Deprecate opam 1.x and better error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Deprecated
 
+- Deprecate opam 1.x (#195, @gpetiot)
+
 ### Fixed
 
 - Separate packages names by spaces in `publish` logs (#171, @hannesm)
@@ -17,6 +19,7 @@
   (#194, @gpetiot)
 - Do not echo input characters when reading token (#199, @gpetiot)
 - Improve the output of VCS command errors (#193, @gpetiot)
+- Better error handling when checking opam version (#195, @gpetiot)
 
 ### Removed
 

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -105,7 +105,7 @@ let lint_opam_github_fields pkg = lint_opam_doc pkg + lint_opam_home_and_dev pkg
 let opam_lint_cmd ~opam_file_version ~opam_tool_version =
   let lint_older_format =
     match (opam_file_version, opam_tool_version) with
-    | Some "1.2", `v2 -> true
+    | Some "1.2", Opam.Version.V2 -> true
     | _ -> false
   in
   Cmd.(Opam.cmd % "lint" %% on lint_older_format (v "--warn=-21-32-48"))
@@ -154,10 +154,10 @@ let extra_opam_lint ~opam_file_version ~opam_file pkg =
   descr_err + github_field_errs
 
 let lint_opam ~dry_run pkg =
-  let opam_tool_version = Lazy.force Opam.version in
+  Lazy.force Opam.Version.cli >>= fun opam_tool_version ->
   Pkg.opam_field_hd pkg "opam-version" >>= fun opam_file_version ->
   match (opam_file_version, opam_tool_version) with
-  | Some "2.0", `v1_2_2 ->
+  | Some "2.0", Opam.Version.V1_2_2 ->
       App_log.status (fun l ->
           l
             "Skipping opam lint as `opam-version` field is \"2.0\" while `opam \

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -93,8 +93,21 @@ module Url : sig
       of file [f]. *)
 end
 
-val version : [ `v1_2_2 | `v2 ] Lazy.t
-(** [version] is the output of [opam --version]. *)
+(** Opam version. *)
+module Version : sig
+  type t = V1_2_2 | V2  (** Supported opam versions. *)
+
+  val pp : Format.formatter -> t -> unit
+
+  val equal : t -> t -> bool
+
+  val of_string : string -> (t, R.msg) result
+  (** [of_string s] returns the supported opam version parsed from [s] or return
+      the associated error message. *)
+
+  val cli : (t, R.msg) result Lazy.t
+  (** [cli] is the output of [opam --version]. *)
+end
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/tests/alcotest_ext.ml
+++ b/tests/alcotest_ext.ml
@@ -6,3 +6,6 @@ let error_msg =
   testable Bos_setup.R.pp_msg (fun (`Msg e1) (`Msg e2) -> String.equal e1 e2)
 
 let result_msg testable = result testable error_msg
+
+let opam_version =
+  testable Dune_release.Opam.Version.pp Dune_release.Opam.Version.equal

--- a/tests/alcotest_ext.mli
+++ b/tests/alcotest_ext.mli
@@ -4,3 +4,5 @@ open Bos_setup
 val path : Fpath.t testable
 
 val result_msg : 'a testable -> ('a, R.msg) result testable
+
+val opam_version : Dune_release.Opam.Version.t testable

--- a/tests/test_opam.ml
+++ b/tests/test_opam.ml
@@ -1,0 +1,27 @@
+let test_version_of_string =
+  let make_test ~input ~expected =
+    let name = "Version.of_string " ^ input in
+    let test_fun () =
+      Alcotest.(check Alcotest_ext.(result_msg opam_version))
+        name expected
+        (Dune_release.Opam.Version.of_string input)
+    in
+    (name, `Quick, test_fun)
+  in
+  let make_failing_test ~input =
+    make_test ~input
+      ~expected:(Bos_setup.R.error_msgf "unsupported opam version: %S" input)
+  in
+  [
+    make_failing_test ~input:"1.0";
+    make_failing_test ~input:"1.0.0";
+    make_failing_test ~input:"1.2.0";
+    make_test ~input:"1.2.2" ~expected:(Ok V1_2_2);
+    make_failing_test ~input:"1.2.2.3";
+    make_failing_test ~input:"2";
+    make_test ~input:"2.0" ~expected:(Ok V2);
+    make_test ~input:"2.0.0" ~expected:(Ok V2);
+    make_test ~input:"2.0.1" ~expected:(Ok V2);
+  ]
+
+let suite = ("Opam", test_version_of_string)

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -2,6 +2,7 @@ let () =
   Alcotest.run "dune-release"
     [
       Test_github.suite;
+      Test_opam.suite;
       Test_pkg.suite;
       Test_stdext.suite;
       Test_tags.suite;


### PR DESCRIPTION
Fix #186 

- use OpamVersion from opam-core instead of invoking `opam --version`
- don't use lazy
- use Result types instead of exceptions 
- emit a warning when opam < 2.0
- add a simple test (CI only uses opam 2.0)