### PR TITLE
Support some common alternative names for standard files.

### DIFF
--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -139,14 +139,14 @@ let delegate p =
 let build_dir p =
   match p.build_dir with Some b -> Ok b | None -> Ok (Fpath.v "_build")
 
-let find_files path ~name_wo_ext =
+let find_files path ~names_wo_ext =
   OS.Dir.contents path >>| fun files ->
-  Stdext.Path.find_files files ~name_wo_ext
+  Stdext.Path.find_files files ~names_wo_ext
 
 let readmes p =
   match p.readmes with
   | Some f -> Ok f
-  | None -> find_files (Fpath.v ".") ~name_wo_ext:"readme"
+  | None -> find_files (Fpath.v ".") ~names_wo_ext:[ "readme" ]
 
 let readme p =
   readmes p >>= function
@@ -193,7 +193,7 @@ let opam_descr p =
 let change_logs p =
   match p.change_logs with
   | Some f -> Ok f
-  | None -> find_files (Fpath.v ".") ~name_wo_ext:"changes"
+  | None -> find_files (Fpath.v ".") ~names_wo_ext:[ "changes"; "changelog" ]
 
 let change_log p =
   change_logs p >>= function
@@ -203,7 +203,7 @@ let change_log p =
 let licenses p =
   match p.licenses with
   | Some f -> Ok f
-  | None -> find_files (Fpath.v ".") ~name_wo_ext:"license"
+  | None -> find_files (Fpath.v ".") ~names_wo_ext:[ "license"; "copying" ]
 
 let dev_repo p =
   opam_field_hd p "dev-repo" >>= function

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -20,14 +20,16 @@ module Path = struct
     let last = str.[len - 1] in
     Char.equal last '~' || (Char.equal first '#' && Char.equal last '#')
 
-  let find_files ~name_wo_ext files =
+  let find_files ~names_wo_ext files =
     let open Fpath in
     List.filter
       (fun file ->
         if is_backup_file (filename file) then false
         else
           let normalized = to_string (normalize (rem_ext file)) in
-          String.equal name_wo_ext (String.Ascii.lowercase normalized))
+          List.exists
+            (String.equal (String.Ascii.lowercase normalized))
+            names_wo_ext)
       files
 end
 

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -25,10 +25,10 @@ module Path : sig
       - ends with ['~']
       - or begins with ['#'] and ends with ['#']. *)
 
-  val find_files : name_wo_ext:string -> Fpath.t list -> Fpath.t list
-  (** [find_files ~name_wo_ext files] returns the list of files among [files]
-      whose name without the extension is equal to [name_wo_ext]. Backup files
-      are ignored. *)
+  val find_files : names_wo_ext:string list -> Fpath.t list -> Fpath.t list
+  (** [find_files ~names_wo_ext files] returns the list of files among [files]
+      whose name without extension is equal to an element of [names_wo_ext].
+      Backup files are ignored. *)
 end
 
 (** Interface to the Unix system. *)

--- a/tests/test_stdext.ml
+++ b/tests/test_stdext.ml
@@ -11,19 +11,22 @@ let is_backup_file () =
   check ~input:"foooooooooooo~" ~expected:true
 
 let find_files () =
-  let check ~name ~paths ~name_wo_ext ~expected =
+  let check ~name ~paths ~names_wo_ext ~expected =
     let paths = List.map Fpath.v paths in
     let expected = List.map Fpath.v expected in
-    let actual = Dune_release.Stdext.Path.find_files ~name_wo_ext paths in
+    let actual = Dune_release.Stdext.Path.find_files ~names_wo_ext paths in
     let open Alcotest in
     let open Alcotest_ext in
     (check (list path)) name expected actual
   in
-  check ~name:"Path.find_files empty" ~paths:[] ~name_wo_ext:"" ~expected:[];
-  check ~name:"Path.find_files does not contain" ~name_wo_ext:"foo"
+  check ~name:"Path.find_files no alternative" ~names_wo_ext:[]
+    ~paths:[ "foo"; ".foo"; "foo~" ] ~expected:[];
+  check ~name:"Path.find_files empty" ~paths:[] ~names_wo_ext:[ "" ]
+    ~expected:[];
+  check ~name:"Path.find_files does not contain" ~names_wo_ext:[ "foo" ]
     ~paths:[ "aaa"; "bbb"; "#foo#"; "foo~"; ".foo.md.swp" ]
     ~expected:[];
-  check ~name:"Path.find_files contains" ~name_wo_ext:"foo"
+  check ~name:"Path.find_files contains" ~names_wo_ext:[ "foo" ]
     ~paths:[ "aaa"; "bbb"; "#foo#"; "foo~"; ".foo.md.swp"; "foo"; "foo.ml" ]
     ~expected:[ "foo"; "foo.ml" ]
 


### PR DESCRIPTION
This changes `Stdext.Path.find_files` to accept a list of alternative
names and adds the alternatives

  - COPYING and COPYING.LESSER for license, and
  - ChangeLog for changes.

My motivation for the former is the [GNU conversion for naming the license file(s)](https://www.gnu.org/licenses/gpl-howto.html).  The second is a fairly common convention which I used previously, though I don't mind if we drop it from this PR.

**Note** that the change to `find_files` breaks backwards compatibility for the library. Should we do it differently?
