### PR TITLE
Isolate curl requests and add unit tests

### DIFF
--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -44,3 +44,13 @@ let create_release ~version ~msg ~user ~repo =
   in
   let uri = strf "https://api.github.com/repos/%s/%s/releases" user repo in
   [ "-D"; "-"; "--data"; data; uri ]
+
+let upload_archive ~archive ~user ~repo ~release_id =
+  [
+    "-H";
+    "Content-Type:application/x-tar";
+    "--data-binary";
+    strf "@@%s" (Fpath.to_string archive);
+    strf "https://uploads.github.com/repos/%s/%s/releases/%d/assets?name=%s"
+      user repo release_id (Fpath.filename archive);
+  ]

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -1,0 +1,46 @@
+open Bos_setup
+
+let create_release ~version ~msg ~user ~repo =
+  let data =
+    let escape_for_json s =
+      let len = String.length s in
+      let max = len - 1 in
+      let rec escaped_len i l =
+        if i > max then l
+        else
+          match s.[i] with
+          | '\\' | '\"' | '\n' | '\r' | '\t' -> escaped_len (i + 1) (l + 2)
+          | _ -> escaped_len (i + 1) (l + 1)
+      in
+      let escaped_len = escaped_len 0 0 in
+      if escaped_len = len then s
+      else
+        let b = Bytes.create escaped_len in
+        let rec loop i k =
+          if i > max then Bytes.unsafe_to_string b
+          else
+            match s.[i] with
+            | ('\\' | '\"' | '\n' | '\r' | '\t') as c ->
+                Bytes.set b k '\\';
+                let c =
+                  match c with
+                  | '\\' -> '\\'
+                  | '\"' -> '\"'
+                  | '\n' -> 'n'
+                  | '\r' -> 'r'
+                  | '\t' -> 't'
+                  | _ -> assert false
+                in
+                Bytes.set b (k + 1) c;
+                loop (i + 1) (k + 2)
+            | c ->
+                Bytes.set b k c;
+                loop (i + 1) (k + 1)
+        in
+        loop 0 0
+    in
+    strf "{ \"tag_name\" : \"%s\", \"body\" : \"%s\" }"
+      (escape_for_json version) (escape_for_json msg)
+  in
+  let uri = strf "https://api.github.com/repos/%s/%s/releases" user repo in
+  [ "-D"; "-"; "--data"; data; uri ]

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -54,3 +54,12 @@ let upload_archive ~archive ~user ~repo ~release_id =
     strf "https://uploads.github.com/repos/%s/%s/releases/%d/assets?name=%s"
       user repo release_id (Fpath.filename archive);
   ]
+
+let open_pr ~title ~user ~branch ~body ~opam_repo =
+  let base, repo = opam_repo in
+  let uri = strf "https://api.github.com/repos/%s/%s/pulls" base repo in
+  let data =
+    strf {|{"title": %S,"base": "master", "body": %S, "head": "%s:%s"}|} title
+      body user branch
+  in
+  [ "-D"; "-"; "--data"; data; uri ]

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -43,10 +43,15 @@ let create_release ~version ~msg ~user ~repo =
       (escape_for_json version) (escape_for_json msg)
   in
   let uri = strf "https://api.github.com/repos/%s/%s/releases" user repo in
-  [ "-D"; "-"; "--data"; data; uri ]
+  [ "-L"; "-s"; "-S"; "-K"; "-"; "-D"; "-"; "--data"; data; uri ]
 
 let upload_archive ~archive ~user ~repo ~release_id =
   [
+    "-L";
+    "-s";
+    "-S";
+    "-K";
+    "-";
     "-H";
     "Content-Type:application/x-tar";
     "--data-binary";
@@ -62,4 +67,4 @@ let open_pr ~title ~user ~branch ~body ~opam_repo =
     strf {|{"title": %S,"base": "master", "body": %S, "head": "%s:%s"}|} title
       body user branch
   in
-  [ "-D"; "-"; "--data"; data; uri ]
+  [ "-s"; "-S"; "-K"; "-"; "-D"; "-"; "--data"; data; uri ]

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -1,44 +1,44 @@
 open Bos_setup
 
+let escape_for_json s =
+  let len = String.length s in
+  let max = len - 1 in
+  let rec escaped_len i l =
+    if i > max then l
+    else
+      match s.[i] with
+      | '\\' | '\"' | '\n' | '\r' | '\t' -> escaped_len (i + 1) (l + 2)
+      | _ -> escaped_len (i + 1) (l + 1)
+  in
+  let escaped_len = escaped_len 0 0 in
+  if escaped_len = len then s
+  else
+    let b = Bytes.create escaped_len in
+    let rec loop i k =
+      if i > max then Bytes.unsafe_to_string b
+      else
+        match s.[i] with
+        | ('\\' | '\"' | '\n' | '\r' | '\t') as c ->
+            Bytes.set b k '\\';
+            let c =
+              match c with
+              | '\\' -> '\\'
+              | '\"' -> '\"'
+              | '\n' -> 'n'
+              | '\r' -> 'r'
+              | '\t' -> 't'
+              | _ -> assert false
+            in
+            Bytes.set b (k + 1) c;
+            loop (i + 1) (k + 2)
+        | c ->
+            Bytes.set b k c;
+            loop (i + 1) (k + 1)
+    in
+    loop 0 0
+
 let create_release ~version ~msg ~user ~repo =
   let data =
-    let escape_for_json s =
-      let len = String.length s in
-      let max = len - 1 in
-      let rec escaped_len i l =
-        if i > max then l
-        else
-          match s.[i] with
-          | '\\' | '\"' | '\n' | '\r' | '\t' -> escaped_len (i + 1) (l + 2)
-          | _ -> escaped_len (i + 1) (l + 1)
-      in
-      let escaped_len = escaped_len 0 0 in
-      if escaped_len = len then s
-      else
-        let b = Bytes.create escaped_len in
-        let rec loop i k =
-          if i > max then Bytes.unsafe_to_string b
-          else
-            match s.[i] with
-            | ('\\' | '\"' | '\n' | '\r' | '\t') as c ->
-                Bytes.set b k '\\';
-                let c =
-                  match c with
-                  | '\\' -> '\\'
-                  | '\"' -> '\"'
-                  | '\n' -> 'n'
-                  | '\r' -> 'r'
-                  | '\t' -> 't'
-                  | _ -> assert false
-                in
-                Bytes.set b (k + 1) c;
-                loop (i + 1) (k + 2)
-            | c ->
-                Bytes.set b k c;
-                loop (i + 1) (k + 1)
-        in
-        loop 0 0
-    in
     strf "{ \"tag_name\" : \"%s\", \"body\" : \"%s\" }"
       (escape_for_json version) (escape_for_json msg)
   in

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -1,2 +1,5 @@
 val create_release :
   version:string -> msg:string -> user:string -> repo:string -> string list
+
+val upload_archive :
+  archive:Fpath.t -> user:string -> repo:string -> release_id:int -> string list

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -3,3 +3,11 @@ val create_release :
 
 val upload_archive :
   archive:Fpath.t -> user:string -> repo:string -> release_id:int -> string list
+
+val open_pr :
+  title:string ->
+  user:string ->
+  branch:string ->
+  body:string ->
+  opam_repo:string * string ->
+  string list

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -1,0 +1,2 @@
+val create_release :
+  version:string -> msg:string -> user:string -> repo:string -> string list

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -239,7 +239,7 @@ let curl_open_pr ~token ~dry_run ~title ~distrib_user ~user ~branch ~body
   >>= parse_url
 
 let open_pr ~token ~dry_run ~title ~distrib_user ~user ~branch ~opam_repo body =
-  OS.Cmd.must_exist Cmd.(v "curl" % "-s" % "-S" % "-K" % "-") >>= fun curl ->
+  OS.Cmd.must_exist Cmd.(v "curl") >>= fun curl ->
   curl_open_pr ~token ~dry_run ~title ~distrib_user ~user ~branch ~body
     ~opam_repo curl
 
@@ -266,7 +266,7 @@ let assert_tag_exists ~dry_run tag =
 
 let publish_distrib ~dry_run ~msg ~archive ~yes p =
   let git_for_repo r = Cmd.of_list (Cmd.to_list @@ Vcs.cmd r) in
-  let curl = Cmd.(v "curl" % "-L" % "-s" % "-S" % "-K" % "-") in
+  let curl = Cmd.(v "curl") in
   ( match Pkg.distrib_user_and_repo p with
   | Error _ as e -> if dry_run then Ok (D.user, D.repo) else e
   | r -> r )

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -231,13 +231,8 @@ let curl_open_pr ~token ~dry_run ~title ~distrib_user ~user ~branch ~body
       if Re.execp alread_exists resp then Ok `Already_exists
       else R.error_msgf "Could not find html_url id in response:\n%s." resp
   in
-  let base, repo = opam_repo in
-  let uri = strf "https://api.github.com/repos/%s/%s/pulls" base repo in
-  let data =
-    strf {|{"title": %S,"base": "master", "body": %S, "head": "%s:%s"}|} title
-      body user branch
-  in
-  let cmd = Cmd.(curl % "-D" % "-" % "--data" % data % uri) in
+  let args = Curl.open_pr ~title ~user ~branch ~body ~opam_repo in
+  let cmd = List.fold_left Cmd.( % ) curl args in
   github_auth ~dry_run ~user:distrib_user token >>= fun auth ->
   let default = {|  "html_url": "${pr_url}",|} in
   run_with_auth ~dry_run ~default auth cmd (OS.Cmd.to_string ~trim:false)

--- a/tests/test_curl.ml
+++ b/tests/test_curl.ml
@@ -11,6 +11,11 @@ let test_create_release =
       ~user:"you" ~repo:"some-repo"
       ~expected:
         [
+          "-L";
+          "-s";
+          "-S";
+          "-K";
+          "-";
           "-D";
           "-";
           "--data";
@@ -35,6 +40,11 @@ let test_upload_archive =
       ~repo:"some-repo" ~release_id:27
       ~expected:
         [
+          "-L";
+          "-s";
+          "-S";
+          "-K";
+          "-";
           "-H";
           "Content-Type:application/x-tar";
           "--data-binary";
@@ -60,6 +70,10 @@ let test_open_pr =
       ~opam_repo:("base", "repo")
       ~expected:
         [
+          "-s";
+          "-S";
+          "-K";
+          "-";
           "-D";
           "-";
           "--data";

--- a/tests/test_curl.ml
+++ b/tests/test_curl.ml
@@ -19,4 +19,28 @@ let test_create_release =
         ];
   ]
 
-let suite = ("Curl", test_create_release)
+let test_upload_archive =
+  let make_test ~test_name ~archive ~user ~repo ~release_id ~expected =
+    let test_fun () =
+      let archive = Fpath.v archive in
+      let actual =
+        Dune_release.Curl.upload_archive ~archive ~user ~repo ~release_id
+      in
+      Alcotest.(check (list string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~test_name:"simple" ~archive:"foo.tgz" ~user:"you"
+      ~repo:"some-repo" ~release_id:27
+      ~expected:
+        [
+          "-H";
+          "Content-Type:application/x-tar";
+          "--data-binary";
+          "@foo.tgz";
+          "https://uploads.github.com/repos/you/some-repo/releases/27/assets?name=foo.tgz";
+        ];
+  ]
+
+let suite = ("Curl", test_create_release @ test_upload_archive)

--- a/tests/test_curl.ml
+++ b/tests/test_curl.ml
@@ -1,0 +1,22 @@
+let test_create_release =
+  let make_test ~test_name ~version ~msg ~user ~repo ~expected =
+    let test_fun () =
+      let actual = Dune_release.Curl.create_release ~version ~msg ~user ~repo in
+      Alcotest.(check (list string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~test_name:"simple" ~version:"1.1.0" ~msg:"this is a message"
+      ~user:"you" ~repo:"some-repo"
+      ~expected:
+        [
+          "-D";
+          "-";
+          "--data";
+          {|{ "tag_name" : "1.1.0", "body" : "this is a message" }|};
+          "https://api.github.com/repos/you/some-repo/releases";
+        ];
+  ]
+
+let suite = ("Curl", test_create_release)

--- a/tests/test_curl.ml
+++ b/tests/test_curl.ml
@@ -43,4 +43,29 @@ let test_upload_archive =
         ];
   ]
 
-let suite = ("Curl", test_create_release @ test_upload_archive)
+let test_open_pr =
+  let make_test ~test_name ~title ~user ~branch ~body ~opam_repo ~expected =
+    let test_fun () =
+      let actual =
+        Dune_release.Curl.open_pr ~title ~user ~branch ~body ~opam_repo
+      in
+      Alcotest.(check (list string)) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~test_name:"simple" ~title:"This is a PR" ~user:"you"
+      ~branch:"my-best-pr"
+      ~body:"This PR fixes everything.\nThis is the best PR.\n"
+      ~opam_repo:("base", "repo")
+      ~expected:
+        [
+          "-D";
+          "-";
+          "--data";
+          {|{"title": "This is a PR","base": "master", "body": "This PR fixes everything.\nThis is the best PR.\n", "head": "you:my-best-pr"}|};
+          "https://api.github.com/repos/base/repo/pulls";
+        ];
+  ]
+
+let suite = ("Curl", test_create_release @ test_upload_archive @ test_open_pr)

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -1,6 +1,7 @@
 let () =
   Alcotest.run "dune-release"
     [
+      Test_curl.suite;
       Test_github.suite;
       Test_opam.suite;
       Test_pkg.suite;


### PR DESCRIPTION
Should make the review of #202 easier as we would have unit tests on the curl requests
Each commit can be reviewed independently.