### PR TITLE
Distrib: Push the tag only if necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - Do not remove versioned files from the tarball anymore. We used to exclude
   `.gitignore`, `.gitattributes` and other such files from the archive.
   (#299, @NathanReb)
+- Don't try to push the tag if it is already present and point to the same ref on the remote.
+  `dune-release` must guess which URI to pass to `git push` and may guess it wrong.
+  This change allows users to push the tag manually to avoid using that code. (#219, @Julow)
 
 ### Deprecated
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -290,8 +290,10 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
   remote_has_tag_uptodate () >>= function
   | true ->
       App_log.status (fun l ->
-          l "The tag %a is present and uptodate on the remote." Text.Pp.version
-            tag);
+          l
+            "The tag %a is present and uptodate on the remote: skipping the \
+             tag push"
+            Text.Pp.version tag);
       Ok () (* No need to push, avoiding the need to guess the uri. *)
   | false -> (
       let uri =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -264,14 +264,30 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
       Vcs.commit_id ~dirty:false ~commit_ish:tag vcs >>= fun local_rev ->
       Vcs.ls_remote ~dry_run vcs ~kind:`Tag ~filter:tag dev_repo >>= function
       | [] -> Ok false
-      | (rev, _) :: _ when local_rev = rev -> Ok true
-      | (rev, _) :: _ ->
-          App_log.unhappy (fun l ->
-              l
-                "The tag %a is present on the remote but points to a different \
-                 commit (%a)."
-                Text.Pp.version tag Text.Pp.commit rev);
-          Ok false
+      | (remote_rev_unpeeled, _) :: _ -> (
+          (* Resolve again in case of annotated commits (most common case).
+             This is a no-op for non-annotated commits. In case of error, we
+             can assume that the remote is different because we checked that we
+             have the tag locally. *)
+          match Vcs.commit_id ~commit_ish:remote_rev_unpeeled vcs with
+          | Ok remote_rev when remote_rev = local_rev ->
+              if remote_rev_unpeeled = remote_rev then
+                App_log.unhappy (fun l ->
+                    l
+                      "The tag present on the remote is not annotated (it was \
+                       not created by dune-release tag.)");
+              Ok true
+          | r ->
+              let pp_r fmt = function
+                | Ok remote_rev -> Text.Pp.commit fmt remote_rev
+                | Error _ -> Format.fprintf fmt "that we don't have locally"
+              in
+              App_log.unhappy (fun l ->
+                  l
+                    "The tag %a is present on the remote but points to a \
+                     different commit (%a)."
+                    Text.Pp.version tag pp_r r);
+              Ok false )
   in
   remote_has_tag_uptodate () >>= function
   | true -> Ok () (* No need to push, avoiding the need to guess the uri. *)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -290,7 +290,11 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
               Ok false )
   in
   remote_has_tag_uptodate () >>= function
-  | true -> Ok () (* No need to push, avoiding the need to guess the uri. *)
+  | true ->
+      App_log.status (fun l ->
+          l "The tag %a is present and uptodate on the remote." Text.Pp.version
+            tag);
+      Ok () (* No need to push, avoiding the need to guess the uri. *)
   | false -> (
       let uri =
         match Parse.ssh_uri_from_http dev_repo with

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -37,9 +37,19 @@ module Parse = struct
         user_from_regexp_opt uri "https://github\\.com/\\(.+\\)/.+\\(\\.git\\)?"
     | _ -> None
 
+  let path_from_regexp_opt uri regexp =
+    try
+      Some
+        ( "git@github.com:"
+        ^ Re.(Group.get (exec (Emacs.compile_pat regexp) uri) 1) )
+    with Not_found -> None
+
   let ssh_uri_from_http uri =
-    match String.cut ~sep:"https://github.com/" uri with
-    | Some ("", path) -> Some ("git@github.com:" ^ path)
+    match uri with
+    | _ when Bos_setup.String.is_prefix uri ~affix:"git@" ->
+        path_from_regexp_opt uri "git@github\\.com:\\(.+\\)"
+    | _ when Bos_setup.String.is_prefix uri ~affix:"https://" ->
+        path_from_regexp_opt uri "https://github\\.com/\\(.+\\)"
     | _ -> None
 end
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -268,7 +268,7 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
       | (rev, _) :: _ ->
           App_log.unhappy (fun l ->
               l
-                "The tag %a is present on the remote but point to a different \
+                "The tag %a is present on the remote but points to a different \
                  commit (%a)."
                 Text.Pp.version tag Text.Pp.commit rev);
           Ok false

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -263,8 +263,8 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
     Vcs.ls_remote ~dry_run vcs ~kind:`Tag ~filter:tag dev_repo >>= function
     | [] -> Ok false
     | (remote_rev_unpeeled, _) :: _ -> (
-        (* Resolve again in case of annotated commits (most common case).
-           This is a no-op for non-annotated commits. In case of error, we
+        (* Resolve again in case of annotated tags (most common case).
+           This is a no-op for non-annotated tags. In case of error, we
            can assume that the remote is different because we checked that we
            have the tag locally. *)
         match Vcs.commit_id ~commit_ish:remote_rev_unpeeled vcs with

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -18,6 +18,9 @@ module Parse : sig
       - [user_from_remote_uri "https://github.com/username/repo.git"] returns
         [Some "username"].
       - Returns [None] if [remote_uri] isn't in the expected format. *)
+
+  val ssh_uri_from_http : string -> string
+  (** [ssh_uri_from_http] Guess an SSH URI from a Github HTTP url. *)
 end
 
 (** {1 Publish} *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -19,7 +19,7 @@ module Parse : sig
         [Some "username"].
       - Returns [None] if [remote_uri] isn't in the expected format. *)
 
-  val ssh_uri_from_http : string -> string
+  val ssh_uri_from_http : string -> string option
   (** [ssh_uri_from_http] Guess an SSH URI from a Github HTTP url. *)
 end
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -205,11 +205,7 @@ let licenses p =
 let dev_repo p =
   opam_field_hd p "dev-repo" >>= function
   | None -> Ok None
-  | Some r -> (
-      let uri = chop_git_prefix r in
-      match String.cut ~sep:"https://github.com/" uri with
-      | Some ("", path) -> Ok (Some ("git@github.com:" ^ path))
-      | _ -> Ok (Some uri) )
+  | Some r -> Ok (Some (chop_git_prefix r))
 
 let err_not_found () =
   R.error_msg "no distribution URI found, see dune-release's API documentation."

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -140,6 +140,7 @@ val extract_tag : t -> (string, Sos.error) result
 (** {1 Dev repo} *)
 
 val dev_repo : t -> (string option, Sos.error) result
+(** dev-repo field with the ["git+"] prefix removed. *)
 
 (**/**)
 

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -107,6 +107,19 @@ val tag :
 val delete_tag : dry_run:bool -> t -> string -> (unit, R.msg) result
 (** [delete_tag r t] deletes tag [t] in repo [r]. *)
 
+val ls_remote :
+  dry_run:bool ->
+  t ->
+  ?kind:[ `Branch | `Tag | `All ] ->
+  ?filter:string ->
+  string ->
+  ((string * string) list, R.msg) result
+(** [ls_remote ~dry_run t ?filter upstream] queries the remote server [upstream]
+    and returns the result as a list of pairs [commit_hash, ref_name]. [filter]
+    filters results by matching on ref names, the default is no filtering.
+    [kind] filters results on their kind (branch or tag), the default is [`All].
+    Only implemented for Git. *)
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -196,9 +196,6 @@ We do the whole process, calling publish doc implicitely should succeed
     [-] Publishing to github
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
-    [?] Push tag 0.1.0 to git@github.com:foo/whatever.git? [Y/n]
-    [-] Pushing tag 0.1.0 to git@github.com:foo/whatever.git
-    -: exec: git --git-dir .git push --force git@github.com:foo/whatever.git 0.1.0
     ...
     [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -197,8 +197,8 @@ We do the whole process, calling publish doc implicitely should succeed
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     ...
-    [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
-    [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API
+    [?] Create release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]
+    [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API
     -: exec: curl --user foo:${token} --location --silent --show-error --config -
          --dump-header - --data
          { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n - Change A\n - Change B\n" }
@@ -220,7 +220,6 @@ We do the whole process, calling publish doc implicitely should succeed
     [+] Wrote opam package description _build/whatever-lib.0.1.0/opam
     ...
     [-] Submitting
-    ...
     => exists _build/whatever.0.1.0
     => exists _build/whatever-lib.0.1.0
     [-] Preparing pull request to ocaml/opam-repository

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -98,9 +98,6 @@ We make a dry-run release:
     [-] Publishing to github
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
-    [?] Push tag 0.1.0 to git@github.com:foo/whatever.git? [Y/n]
-    [-] Pushing tag 0.1.0 to git@github.com:foo/whatever.git
-    -: exec: git --git-dir .git push --force git@github.com:foo/whatever.git 0.1.0
     ...
     [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -99,8 +99,8 @@ We make a dry-run release:
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     ...
-    [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
-    [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API
+    [?] Create release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]
+    [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API
     -: exec: curl --user foo:${token} --location --silent --show-error --config -
          --dump-header - --data
          { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n- Some other feature\n" }

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -26,20 +26,18 @@ let test_ssh_uri_from_http =
   let check inp expected =
     let test_name = "Parse.ssh_uri_from_http " ^ inp in
     let result = Dune_release.Github.Parse.ssh_uri_from_http inp in
-    let test_fun () = Alcotest.(check string) inp expected result in
+    let test_fun () = Alcotest.(check (option string)) inp expected result in
     (test_name, `Quick, test_fun)
   in
   [
     (* Use cases *)
     check "https://github.com/ocamllabs/dune-release"
-      "git@github.com:ocamllabs/dune-release";
-    check "git@github.com:ocamllabs/dune-release"
-      "git@github.com:ocamllabs/dune-release";
+      (Some "git@github.com:ocamllabs/dune-release");
+    check "git@github.com:ocamllabs/dune-release" None;
     (* This function only works for github https urls, returns its input
        otherwise *)
-    check "https://not-github.com/dune-release"
-      "https://not-github.com/dune-release";
-    check "git@not-github.com:dune-release" "git@not-github.com:dune-release";
+    check "https://not-github.com/dune-release" None;
+    check "git@not-github.com:dune-release" None;
   ]
 
 let suite = ("Github", test_user_from_remote @ test_ssh_uri_from_http)

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -33,7 +33,8 @@ let test_ssh_uri_from_http =
     (* Use cases *)
     check "https://github.com/ocamllabs/dune-release"
       (Some "git@github.com:ocamllabs/dune-release");
-    check "git@github.com:ocamllabs/dune-release" None;
+    check "git@github.com:ocamllabs/dune-release"
+      (Some "git@github.com:ocamllabs/dune-release");
     (* This function only works for github https urls, returns its input
        otherwise *)
     check "https://not-github.com/dune-release" None;

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -22,4 +22,24 @@ let test_user_from_remote =
     make_test "https://github.com/username/repo.git" (Some "username");
   ]
 
-let suite = ("Github", test_user_from_remote)
+let test_ssh_uri_from_http =
+  let check inp expected =
+    let test_name = "Parse.ssh_uri_from_http " ^ inp in
+    let result = Dune_release.Github.Parse.ssh_uri_from_http inp in
+    let test_fun () = Alcotest.(check string) inp expected result in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    (* Use cases *)
+    check "https://github.com/ocamllabs/dune-release"
+      "git@github.com:ocamllabs/dune-release";
+    check "git@github.com:ocamllabs/dune-release"
+      "git@github.com:ocamllabs/dune-release";
+    (* This function only works for github https urls, returns its input
+       otherwise *)
+    check "https://not-github.com/dune-release"
+      "https://not-github.com/dune-release";
+    check "git@not-github.com:dune-release" "git@not-github.com:dune-release";
+  ]
+
+let suite = ("Github", test_user_from_remote @ test_ssh_uri_from_http)


### PR DESCRIPTION
Check that the tag is already present on the remote and point to the same rev as the local tag.
Don't try to push it again if that's true.

This fixes issue https://github.com/ocamllabs/dune-release/issues/172

Pushing the tag may fail because the guessed URI may be wrong or git may not have access to keys necessary for authentication.
That can happen when the user have aliases for SSH hosts, when the HTTPs protocol is usually used (the user has no key), when the user don't use command line git, or when `dune-release` is sandboxed.

This allows users to push the tag themselves and continue working with the tool when they encounter issues https://github.com/ocamllabs/dune-release/issues/203 and https://github.com/ocamllabs/dune-release/issues/169
