### PR TITLE
Add a config subcommand to display and edit global configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,13 @@
 
 ### Added
 
+<<<<<<< HEAD
 - Add command `delegate-info` to print information needed by external 
   release scripts (#221, @pitag-ha)
+=======
+- Add a `dune-release config` subcommand to display and edit the global
+  configuration (#220, @NathanReb).
+>>>>>>> c484560... Add a config subcommand to display and edit global configuration
 
 ### Changed
 

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -1,0 +1,144 @@
+open Dune_release
+
+let invalid_config_key key =
+  Rresult.R.error_msgf "%S is not a valid global config field" key
+
+let show_val = function None -> "<unset>" | Some x -> x
+
+let log_val string_opt =
+  Logs.app (fun l -> l "%s" (show_val string_opt));
+  Ok ()
+
+let show key =
+  let open Rresult.R.Infix in
+  Config.load () >>= fun config ->
+  match key with
+  | None ->
+      let pretty_fields = Config.pretty_fields config in
+      StdLabels.List.iter pretty_fields ~f:(fun (key, value) ->
+          Logs.app (fun l -> l "%s: %s" key (show_val value)));
+      Ok ()
+  | Some "user" -> log_val config.user
+  | Some "remote" -> log_val config.remote
+  | Some "local" -> log_val (Stdext.Option.map ~f:Fpath.to_string config.local)
+  | Some "keep-v" -> log_val (Stdext.Option.map ~f:string_of_bool config.keep_v)
+  | Some "auto-open" ->
+      log_val (Stdext.Option.map ~f:string_of_bool config.auto_open)
+  | Some key -> invalid_config_key key
+
+let to_bool ~field value =
+  match String.lowercase_ascii value with
+  | "true" -> Ok true
+  | "false" -> Ok false
+  | _ -> Rresult.R.error_msgf "Invalid value %S for field %s" value field
+
+let set key value =
+  let open Rresult.R.Infix in
+  Config.load () >>= fun config ->
+  let updated =
+    match key with
+    | "user" -> Ok { config with user = Some value }
+    | "remote" -> Ok { config with remote = Some value }
+    | "local" ->
+        Fpath.of_string value >>| fun v -> { config with local = Some v }
+    | "keep-v" ->
+        to_bool ~field:key value >>| fun v -> { config with keep_v = Some v }
+    | "auto-open" ->
+        to_bool ~field:key value >>| fun v -> { config with auto_open = Some v }
+    | _ -> invalid_config_key key
+  in
+  updated >>= Config.save >>= fun () -> Ok ()
+
+let default_usage ?raw () =
+  let cmd = "dune-release config" in
+  match raw with Some () -> cmd | None -> Printf.sprintf "$(b,%s)" cmd
+
+let show_usage ?raw () =
+  let cmd = "dune-release config show" in
+  let key = "KEY" in
+  match raw with
+  | Some () -> Printf.sprintf "%s [%s]" cmd key
+  | None -> Printf.sprintf "$(b,%s) [$(i,%s)]" cmd key
+
+let set_usage ?raw () =
+  let cmd = "dune-release config set" in
+  let key = "KEY" in
+  let value = "VALUE" in
+  match raw with
+  | Some () -> Printf.sprintf "%s %s %s" cmd key value
+  | None -> Printf.sprintf "$(b,%s) $(i,%s) $(i,%s)" cmd key value
+
+let invalid_usage () =
+  Rresult.R.error_msgf
+    "Invalid dune-release config invocation. Usage:\n%s\n%s\n%s"
+    (default_usage ~raw:() ()) (show_usage ~raw:() ()) (set_usage ~raw:() ())
+
+let run action key_opt value_opt =
+  let res =
+    match (action, key_opt, value_opt) with
+    | "show", key, None -> show key
+    | "set", Some key, Some value -> set key value
+    | _ -> invalid_usage ()
+  in
+  match res with
+  | Ok () -> 0
+  | Error (`Msg s) ->
+      App_log.unhappy (fun l -> l "%s" s);
+      1
+
+let man =
+  let open Cmdliner in
+  [
+    `S Manpage.s_synopsis;
+    `P (default_usage ());
+    `P (show_usage ());
+    `P (set_usage ());
+    `S "GLOBAL CONFIGURATION FIELDS";
+    `P
+      "Here are the existing fields of dune-release's global config file. Only \
+       those values should be used as $(i,KEY):";
+    `P
+      "$(b,user): The Github username of the opam-repository fork. Used to \
+       open the final PR to opam-repository.";
+    `P
+      "$(b,remote): The URL to your remote Github opam-repository fork. Used \
+       to open the final PR to opam-repository.";
+    `P
+      "$(b,local): The path to your local clone of opam-repository. Used to \
+       open the final PR to opam-repository.";
+    `P
+      "$(b,keep-v): Whether or not the 'v' prefix in git tags should make it \
+       to the final version number.";
+    `P
+      "$(b,auto-open): Whether dune-release should open your browser to the \
+       newly created opam-repository PR or not.";
+  ]
+
+let info =
+  let doc = "Displays or update dune-release global configuration" in
+  Cmdliner.Term.info ~doc ~man "config"
+
+let action =
+  let docv = "ACTION" in
+  let doc =
+    "The action to perform, either $(b,show) the config or $(b,set) a config \
+     field"
+  in
+  Cmdliner.Arg.(value & pos 0 string "show" & info ~doc ~docv [])
+
+let key =
+  let docv = "KEY" in
+  let doc =
+    "The configuration field to set or print. For $(b,show), if no key is \
+     provided, the entire config will be printed."
+  in
+  Cmdliner.Arg.(value & pos 1 (some string) None & info ~doc ~docv [])
+
+let value =
+  let docv = "VALUE" in
+  let doc = "The new field value" in
+  Cmdliner.Arg.(value & pos 2 (some string) None & info ~doc ~docv [])
+
+let term = Cmdliner.Term.(pure run $ action $ key $ value)
+
+let cmd = (term, info)

--- a/bin/config.mli
+++ b/bin/config.mli
@@ -1,0 +1,1 @@
+val cmd : int Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -16,6 +16,7 @@ let cmds =
     Bistro.cmd;
     Lint.cmd;
     Delegate_info.cmd;
+    Config.cmd;
   ]
 
 (* Command line interface *)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -36,3 +36,11 @@ val token : dry_run:bool -> unit -> (Fpath.t, Bos_setup.R.msg) result
 val keep_v : bool -> (bool, Bos_setup.R.msg) result
 
 val auto_open : bool -> (bool, Bos_setup.R.msg) result
+
+val load : unit -> (t, Bos_setup.R.msg) result
+
+val save : t -> (unit, Bos_setup.R.msg) result
+
+val pretty_fields : t -> (string * string option) list
+(** [pretty_fields t] returns the list of pretty-printed key-value pairs for the
+    config [t]. *)

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -47,3 +47,17 @@ module Unix = struct
   let read_line ?(echo_input = true) () =
     maybe_echo_input echo_input read_line ()
 end
+
+module Option = struct
+  let map ~f = function None -> None | Some x -> Some (f x)
+end
+
+module List = struct
+  let filter_map ~f l =
+    let rec fmap acc = function
+      | [] -> List.rev acc
+      | hd :: tl -> (
+          match f hd with None -> fmap acc tl | Some x -> fmap (x :: acc) tl )
+    in
+    fmap [] l
+end

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -38,3 +38,11 @@ module Unix : sig
       standard input. If [echo_input] is [true] (by default) input characters
       are echoed on the standard output. *)
 end
+
+module Option : sig
+  val map : f:('a -> 'b) -> 'a option -> 'b option
+end
+
+module List : sig
+  val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
+end


### PR DESCRIPTION
Fixes #185 

This PR add a new subcommand to display and edit the global dune-release configuration, along with a bit of documentation as to what each of the fields is used for.

This should make the global config and its components more discoverable for users.

While working on this I noticed that the user field might not be of any use and that it may even cause bugs if it differs from the one in the remote opam-repo URL. We should take a look at this separately!