### PR TITLE
Add new command: delegate-info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Add command `delegate-info` to print information needed by external 
+  release scripts (#221, @pitag-ha)
+
 ### Changed
 
 ### Deprecated

--- a/bin/delegate_info.ml
+++ b/bin/delegate_info.ml
@@ -1,0 +1,32 @@
+open Cmdliner
+open Dune_release
+
+let run var =
+  let open Rresult in
+  let pkg = Pkg.v ~dry_run:false () in
+  let result =
+    match var with
+    | "tarball" ->
+        Pkg.distrib_file ~dry_run:false pkg >>| fun distrib_file ->
+        Format.printf "%a\n" Fpath.pp distrib_file
+    | "docdir" -> Ok (Format.printf "%a\n" Fpath.pp Pkg.doc_dir)
+    | "publication-message" ->
+        Pkg.publish_msg pkg >>| fun msg -> Format.printf "%s\n" msg
+    | _ -> Rresult.R.error_msgf "Unknown variable %S" var
+  in
+  match result with
+  | Ok _ -> 0
+  | Error (`Msg msg) ->
+      App_log.unhappy (fun m -> m "%s" msg);
+      1
+
+let var =
+  let doc = "The variable to print." in
+  Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"VAR")
+
+let term = Term.(pure run $ var)
+
+let info =
+  Term.info "delegate-info" ~doc:"Prints out the given variable to stdout"
+
+let cmd = (term, info)

--- a/bin/delegate_info.mli
+++ b/bin/delegate_info.mli
@@ -1,0 +1,1 @@
+val cmd : int Cmdliner.Term.t * Cmdliner.Term.info

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -8,7 +8,14 @@ open Cmdliner
 
 let cmds =
   [
-    Tag.cmd; Distrib.cmd; Publish.cmd; Opam.cmd; Help.cmd; Bistro.cmd; Lint.cmd;
+    Tag.cmd;
+    Distrib.cmd;
+    Publish.cmd;
+    Opam.cmd;
+    Help.cmd;
+    Bistro.cmd;
+    Lint.cmd;
+    Delegate_info.cmd;
   ]
 
 (* Command line interface *)

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -10,7 +10,7 @@ open Dune_release
 let gen_doc ~dry_run ~force dir pkg_names =
   let names = String.concat ~sep:"," pkg_names in
   let build_doc = Cmd.(v "dune" % "build" % "-p" % names % "@doc") in
-  let doc_dir = Fpath.(v "_build" / "default" / "_doc" / "_html") in
+  let doc_dir = Pkg.doc_dir in
   let do_doc () = Sos.run ~dry_run ~force build_doc in
   R.join @@ Sos.with_dir ~dry_run dir do_doc () >>= fun () ->
   Ok Fpath.(dir // doc_dir)

--- a/lib/delegate.ml
+++ b/lib/delegate.ml
@@ -35,21 +35,16 @@ let publish_distrib ~dry_run ~msg ~archive ~yes pkg =
           v "publish" % "distrib" % distrib_uri % name % version % msg
           % p archive)
 
-let publish_doc ~dry_run ~msg ~docdir ~yes p =
-  Pkg.delegate p >>= function
+let publish_doc ~dry_run ~msg ~docdir ~yes pkg =
+  Pkg.delegate pkg >>= function
   | None ->
       App_log.status (fun l -> l "Publishing to github");
-      Github.publish_doc ~dry_run ~msg ~docdir ~yes p
+      Github.publish_doc ~dry_run ~msg ~docdir ~yes pkg
   | Some del ->
       App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
-      let doc_uri p =
-        Pkg.opam_field_hd p "doc" >>= function
-        | None -> Ok ""
-        | Some uri -> Ok uri
-      in
-      Pkg.name p >>= fun name ->
-      Pkg.version p >>= fun version ->
-      doc_uri p >>= fun doc_uri ->
+      Pkg.name pkg >>= fun name ->
+      Pkg.version pkg >>= fun version ->
+      Pkg.doc_uri pkg >>= fun doc_uri ->
       run_delegate ~dry_run del
         Cmd.(v "publish" % "doc" % doc_uri % name % version % msg % p docdir)
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -341,6 +341,8 @@ let distrib_user_and_repo p =
 let doc_uri p =
   opam_field_hd p "doc" >>| function None -> "" | Some uri -> uri
 
+let doc_dir = Fpath.(v "_build" / "default" / "_doc" / "_html")
+
 let doc_user_repo_and_path p =
   doc_uri p >>= fun uri ->
   (* Parses the $PATH of $SCHEME://$HOST/$REPO/$PATH *)

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -125,6 +125,10 @@ val publish_artefacts :
 
 (** {1 Uri} *)
 
+val doc_uri : t -> (string, Bos_setup.R.msg) result
+
+val doc_dir : Fpath.t
+
 val doc_user_repo_and_path : t -> (string * string * Fpath.t, R.msg) result
 
 val distrib_user_and_repo : t -> (string * string, R.msg) result


### PR DESCRIPTION
This new command delegate-info allows the user to obtain:
- the relative path to the tarball ("tarbal" as argument)
- the relative path to the documentation ("docdir" as argument)
- the publication message ("publication-message" as argument)