### PR TITLE
Removing dead code

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -178,7 +178,7 @@ let warn_if_vcs_dirty msg =
 let handle_error = function
   | Ok 0 -> if Logs.err_count () > 0 then 3 else 0
   | Ok n -> n
-  | Error _ as r -> Logs.on_error_msg ~use:(fun _ -> 3) r
+  | Error _ as r -> Logs.on_error_msg ~use:(fun () -> 3) r
 
 let exits =
   Term.exit_info 3 ~doc:"on indiscriminate errors reported on stderr."

--- a/lib/archive.ml
+++ b/lib/archive.ml
@@ -148,8 +148,6 @@ let bzip2 ~dry_run ?force ~dst s =
 
 let tar_cmd = OS.Env.(value "DUNE_RELEASE_TAR" cmd ~absent:(Cmd.v "tar"))
 
-let ensure_tar () = OS.Cmd.must_exist tar_cmd >>| fun _ -> ()
-
 let untbz ~dry_run ?(clean = false) ar =
   let clean_dir dir =
     OS.Dir.exists dir >>= function

--- a/lib/archive.mli
+++ b/lib/archive.mli
@@ -35,9 +35,6 @@ val bzip2 :
   dry_run:bool -> ?force:bool -> dst:Fpath.t -> string -> (unit, R.msg) result
 (** [bzip2 dst s] compresses [s] to [dst] using bzip2. *)
 
-val ensure_tar : unit -> (unit, R.msg) result
-(** [ensure_tar ()] makes sure the [tar] utility is available. *)
-
 val untbz : dry_run:bool -> ?clean:bool -> Fpath.t -> (Fpath.t, R.msg) result
 (** [untbz ~clean ar] untars the tar bzip2 archive [ar] in the same directory as
     [ar] and returns a base directory for [ar]. If [clean] is [true] (defaults

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -29,8 +29,6 @@ val v :
   Pkg.t list ->
   (t, Bos_setup.R.msg) result
 
-val find : unit -> (t option, Bos_setup.R.msg) result
-
 val token : dry_run:bool -> unit -> (Fpath.t, Bos_setup.R.msg) result
 
 val keep_v : bool -> (bool, Bos_setup.R.msg) result

--- a/lib/distrib.ml
+++ b/lib/distrib.ml
@@ -8,8 +8,6 @@ open Rresult
 
 (* Defaults *)
 
-let default_massage () = Ok ()
-
 let default_exclude_paths () =
   let l =
     List.map Fpath.v

--- a/lib/distrib.mli
+++ b/lib/distrib.mli
@@ -33,30 +33,6 @@ val v :
       massaging, to determine the paths that are excluded from being added to
       the distribution archive. Defaults to {!exclude_paths}. *)
 
-val default_massage : unit -> (unit, R.msg) result
-(** [default_massage] is the default distribution massaging function. It is
-    invoked in the distribution build directory and does nothing. *)
-
-val default_exclude_paths : unit -> (Fpath.t list, R.msg) result
-(** [default_exclude_paths ()] is the default list of paths to exclude from the
-    distribution archive. It is invoked in the distribution build directory and
-    returns the following static set of files.
-
-    {[
-      fun () ->
-        Ok
-          [
-            ".git";
-            ".gitignore";
-            ".gitattributes";
-            ".hg";
-            ".hgignore";
-            "build";
-            "Makefile";
-            "_build";
-          ]
-    ]} *)
-
 val massage : t -> unit -> (unit, R.msg) result
 
 val exclude_paths : t -> unit -> (Fpath.t list, R.msg) result

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -44,17 +44,6 @@ val publish_doc :
   Pkg.t ->
   (unit, R.msg) Result.result
 
-val publish_in_git_branch :
-  dry_run:bool ->
-  remote:string ->
-  branch:string ->
-  name:string ->
-  version:string ->
-  docdir:Fpath.t ->
-  dir:Fpath.t ->
-  yes:bool ->
-  (unit, R.msg) result
-
 val open_pr :
   token:Fpath.t ->
   dry_run:bool ->

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -145,12 +145,6 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
     ()
   |> R.join
 
-(* Packages *)
-
-let ocaml_base_packages =
-  String.Set.of_list
-    [ "base-bigarray"; "base-bytes"; "base-threads"; "base-unix" ]
-
 (* Files *)
 
 module File = struct
@@ -196,10 +190,6 @@ module File = struct
       opt_field "synopsis" OpamFile.OPAM.synopsis (list id);
     ]
 
-  let field_names =
-    let add acc (name, _) = String.Set.add name acc in
-    List.fold_left add String.Set.empty fields
-
   let fields ~dry_run file =
     if not (Sys.file_exists (Fpath.to_string file)) then
       R.error_msgf "Internal error: file %a not found" Fpath.pp file
@@ -222,21 +212,6 @@ module File = struct
           (* Apparently in at least opam-lib 1.2.2, the error will be
              logged on stdout. *)
           R.error_msgf "%a: could not parse opam file" Fpath.pp file
-
-  let deps ?(opts = true) fields =
-    let deps =
-      match String.Map.find "depends" fields with
-      | None -> []
-      | Some deps -> deps
-    in
-    let dep_opts =
-      if not opts then []
-      else
-        match String.Map.find "depopts" fields with
-        | None -> []
-        | Some deps -> deps
-    in
-    String.Set.of_list (List.rev_append dep_opts deps)
 end
 
 module Descr = struct

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -28,33 +28,16 @@ val prepare :
     branch in the local opam repository [local_repo], using the commit message
     [msg] (if any). Return the new branch. *)
 
-(** {1:pkgs Packages} *)
-
-val ocaml_base_packages : String.set
-(** [ocaml_base_packages] are the base opam packages distributed with OCaml:
-    ["base-bigarray"], ["base-bytes"], ["base-threads"], ["base-unix"]. *)
-
 (** {1:file Files} *)
 
 (** opam files *)
 module File : sig
   (** {1:file opam file} *)
 
-  val field_names : String.set
-  (** [field_names] is the maximal domain of the map returned by {!fields},
-      excluding extension fields (not yet supported by [opam-lib] 1.2.2). *)
-
   val fields : dry_run:bool -> Fpath.t -> (string list String.map, R.msg) result
   (** [fields f] returns a simplified model of the fields of the opam file [f].
       The domain of the result is included in {!field_names}. Note that the
       [depends:] and [depopts:] fields are returned without version constraints. *)
-
-  (** {1:deps Dependencies} *)
-
-  val deps : ?opts:bool -> string list String.map -> String.set
-  (** [deps ~opts fields] returns the packages mentioned in the [depends:]
-      fields, if [opts] is [true] (default) those from [depopts:] are added
-      aswell. *)
 end
 
 (** [descr] files. *)
@@ -70,10 +53,6 @@ module Descr : sig
   val to_string : t -> string
   (** [to_string d] is [d] as a string. *)
 
-  val of_readme : ?flavour:Text.flavour -> string -> (t, R.msg) result
-  (** [of_readme r] extracts an opam description file from a readme [r] with a
-      certain structure. *)
-
   val of_readme_file : Fpath.t -> (t, R.msg) result
   (** [of_readme_file f] extracts an opam description file from a readme file
       [f] using {!Text.flavour_of_fpath} and {!of_readme}. *)
@@ -82,10 +61,6 @@ end
 (** [url] files. *)
 module Url : sig
   (** {1:url Url file} *)
-
-  val v : uri:string -> file:string -> OpamFile.URL.t
-  (** [v ~uri ~file] is an URL file for URI [uri] with checksums computes on
-      [file]. *)
 
   val with_distrib_file :
     dry_run:bool -> uri:string -> Fpath.t -> (OpamFile.URL.t, R.msg) result

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -518,7 +518,7 @@ let distrib_version_opam_files ~dry_run ~version =
   infer_pkg_names Fpath.(v ".") [] >>= fun names ->
   List.fold_left
     (fun acc name ->
-      acc >>= fun _acc ->
+      acc >>= fun () ->
       let file = Fpath.(v name + "opam") in
       OS.File.read_lines file >>= fun content ->
       let content = prepare_opam_for_distrib ~version ~content in
@@ -583,9 +583,6 @@ let test ~dry_run ~dir ~args ~out p =
 
 let build ~dry_run ~dir ~args ~out p =
   run ~dry_run ~dir ~args ~out ~default:(Sos.out "") p "build"
-
-let clean ~dry_run ~dir ~args ~out p =
-  run ~dry_run ~dir ~args ~out ~default:(Sos.out "") p "clean"
 
 (* tags *)
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -516,14 +516,11 @@ let prepare_opam_for_distrib ~version ~content =
 
 let distrib_version_opam_files ~dry_run ~version =
   infer_pkg_names Fpath.(v ".") [] >>= fun names ->
-  List.fold_left
-    (fun acc name ->
-      acc >>= fun () ->
+  Stdext.Result.List.iter names ~f:(fun name ->
       let file = Fpath.(v name + "opam") in
       OS.File.read_lines file >>= fun content ->
       let content = prepare_opam_for_distrib ~version ~content in
       Sos.write_file ~dry_run file (String.concat ~sep:"\n" content))
-    (Ok ()) names
 
 let distrib_prepare ~dry_run p ~dist_build_dir ~version =
   let d = p.distrib in

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -34,9 +34,6 @@ val v :
   unit ->
   t
 
-val infer_name : Fpath.t -> (string, R.msg) result
-(** Infer the name of the projet. *)
-
 val infer_pkg_names : Fpath.t -> string list -> (string list, R.msg) result
 (** Infer the package list. *)
 
@@ -73,14 +70,8 @@ val opam_field : t -> string -> (string list option, R.msg) result
 
 val opam_field_hd : t -> string -> (string option, Sos.error) result
 
-val opam_fields : t -> (string list String.map, R.msg) result
-(** [opam_fields p] are [p]'s opam file fields. *)
-
 val readmes : t -> (Fpath.t list, R.msg) result
 (** [readmes p] are [p]'s readme files. *)
-
-val readme : t -> (Fpath.t, R.msg) result
-(** [readme p] is the first element of [readmes p]. *)
 
 val change_logs : t -> (Fpath.t list, R.msg) result
 (** [change_logs p] are [p]'s change logs. *)
@@ -148,10 +139,6 @@ val test : f
 (** {1 Build} *)
 
 val build : f
-
-(** {1 Clean} *)
-
-val clean : f
 
 (** {1 Tag} *)
 

--- a/lib/sos.ml
+++ b/lib/sos.ml
@@ -39,7 +39,7 @@ let last_dir = ref root
 
 let pp_cmd ppf cmd =
   let x = Fmt.to_to_string Cmd.pp cmd in
-  let x = String.mapi (fun _ -> function '\n' -> ' ' | c -> c) x in
+  let x = String.map (function '\n' -> ' ' | c -> c) x in
   Fmt.string ppf x
 
 let show ?sandbox ?(action = `Skip) fmt =

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -52,6 +52,13 @@ module Option = struct
   let map ~f = function None -> None | Some x -> Some (f x)
 end
 
+module Result = struct
+  module List = struct
+    let iter ~f l =
+      List.fold_left (fun acc x -> acc >>= fun () -> f x) (Ok ()) l
+  end
+end
+
 module List = struct
   let filter_map ~f l =
     let rec fmap acc = function

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -46,3 +46,12 @@ end
 module List : sig
   val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
 end
+
+module Result : sig
+  module List : sig
+    val iter :
+      f:('a -> (unit, 'e) Result.result) -> 'a list -> (unit, 'e) Result.result
+    (** [iter ~f l] applies [f] on each element of list [l] until an error
+        occurs. *)
+  end
+end

--- a/lib/text.ml
+++ b/lib/text.ml
@@ -130,41 +130,6 @@ let split_uri ?(rel = false) uri =
           let path = if rel then path else "/" ^ path in
           Some (scheme, host, path) )
 
-(* Edit and page text *)
-
-let find_pager ~don't =
-  if don't then Ok None
-  else
-    match OS.Env.var "TERM" with
-    | Some "dumb" | None -> Ok None
-    | _ ->
-        let add_env v cmds =
-          match OS.Env.(value v (some cmd) ~absent:None) with
-          | None -> cmds
-          | Some cmd -> cmd :: cmds
-        in
-        let cmds = [ Cmd.v "less"; Cmd.v "more" ] in
-        let cmds = add_env "PAGER" cmds in
-        let rec loop = function
-          | [] -> Ok None
-          | cmd :: cmds -> (
-              OS.Cmd.exists cmd >>= function
-              | true -> Ok (Some cmd)
-              | false -> loop cmds )
-        in
-        loop cmds
-
-let edit_file f =
-  let editor = OS.Env.(value "EDITOR" cmd ~absent:(Cmd.v "nano")) in
-  OS.Cmd.exists editor >>= function
-  | false ->
-      R.error_msgf
-        "Editor %a not in search path. Set the EDITOR environment variable."
-        Cmd.pp editor
-  | true -> (
-      OS.Cmd.(run_status Cmd.(editor % p f)) >>= function
-      | `Exited n | `Signaled n -> Ok n )
-
 (* Pretty-printers. *)
 
 module Pp = struct

--- a/lib/text.mli
+++ b/lib/text.mli
@@ -42,13 +42,6 @@ val header_title : ?flavour:flavour -> string -> string
 
 (** {1 Toy change log parsing} *)
 
-val change_log_last_entry :
-  ?flavour:flavour -> string -> (string * (string * string)) option
-(** [change_log_last_version ~flavour text] tries to parse the last change log
-    entry of [text] (i.e. the {!head} of [text]) into
-    [Some (version, (header, text))], where [(header,text)] is the result of
-    {!head} and [version] a version number extracted from [header]. *)
-
 val change_log_file_last_entry :
   Fpath.t -> (string * (string * string), R.msg) result
 (** [change_log_file_last_entry file] tries to parse the last change log entry
@@ -60,18 +53,6 @@ val change_log_file_last_entry :
 val split_uri : ?rel:bool -> string -> (string * string * string) option
 (** [split_uri uri] splits [uri] into a triple [(scheme, host, path)]. If [rel]
     is [true] (defaults to [false]), a leading ["/"] in [path] is removed. *)
-
-(** {1 Edit and page text} *)
-
-val edit_file : Fpath.t -> (int, R.msg) result
-(** [edit_file f] invokes the tool mentioned in the [EDITOR] environment
-    variable with [f] and returns the exit code of the program. *)
-
-val find_pager : don't:bool -> (Cmd.t option, R.msg) result
-(** [find ~no_pager] is an optional pager command. If [don't] is [true] returns
-    [None]. Otherwise first consults the [PAGER] environment variable, then
-    tries [less] or [more] in that order. If the [TERM] environment variable is
-    ["dumb"] or undefined unconditionaly returns [None]. *)
 
 (** Pretty printers. *)
 module Pp : sig

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -12,12 +12,6 @@ open Rresult
 
 (** {1:vcsops Version control system repositories} *)
 
-type kind = [ `Git | `Hg ]
-(** The type for version control systems (VCS). *)
-
-val pp_kind : Format.formatter -> kind -> unit
-(** [pp_kind ppf k] prints an unspecified representation of [k] on [ppf]. *)
-
 type commit_ish = string
 (** The type for symbols resolving to a commit. The module uses ["HEAD"] for
     specifying the current checkout; use this symbol even if the underlying VCS
@@ -25,12 +19,6 @@ type commit_ish = string
 
 type t
 (** The type for version control systems repositories. *)
-
-val kind : t -> kind
-(** [kind r] is [r]'s VCS kind. *)
-
-val dir : t -> Fpath.t
-(** [dir r] is [r]'s repository directory. *)
 
 val cmd : t -> Bos.Cmd.t
 (** [cmd r] is the base VCS command to use to act on [r].
@@ -41,33 +29,14 @@ val cmd_error : Bos.Cmd.t -> Bos.OS.Cmd.status -> ('a, R.msg) result
 (** [cmd_error cmd status] returns an error message describing the failing
     command [cmd] and the exit status [status]. *)
 
-val find : ?dir:Fpath.t -> unit -> (t option, R.msg) result
-(** [find ~dir ()] looks for a VCS repository in working directory [dir] (not
-    the repository directory like [.git], default is guessed automatically). *)
-
 val get : ?dir:Fpath.t -> unit -> (t, R.msg) result
 (** [get] is like {!find} but returns an error if no VCS was found. *)
-
-val pp : Format.formatter -> t -> unit
-(** [pp ppf r] prints an unspecified representation of [r] on [ppf]. *)
 
 (** {1:state Repository state} *)
 
 val is_dirty : t -> (bool, R.msg) result
 (** [is_dirty r] is [Ok true] iff the working tree of [r] has uncommited
     changes. *)
-
-val not_dirty : t -> (unit, R.msg) result
-(** [not_dirty] is [Ok ()] iff the working directory of [r] is not dirty and an
-    error that enjoins to stash or commit otherwise. *)
-
-val file_is_dirty : t -> Fpath.t -> (bool, R.msg) result
-(** [file_id_dirty r f] is [Ok true] iff [f] has uncommited changes. *)
-
-val head : ?dirty:bool -> t -> (string, R.msg) result
-(** [head ~dirty r] is the HEAD commit identifier of the repository [r]. If
-    [dirty] is [true] (default), and indicator is appended to the commit
-    identifier if the working tree of [r] {!is_dirty}. *)
 
 val commit_id :
   ?dirty:bool -> ?commit_ish:commit_ish -> t -> (string, R.msg) result
@@ -88,26 +57,11 @@ val describe :
     and [dirty] is [true] (default) an indicator is appended to the identifier
     if the working tree is dirty. *)
 
-val tags : t -> (string list, R.msg) result
-(** [tags r] is the list of tags in the repo [r]. *)
-
 val tag_exists : dry_run:bool -> t -> string -> bool
 
 val tag_points_to : t -> tag:string -> string option
 
 val branch_exists : dry_run:bool -> t -> string -> bool
-
-val changes :
-  ?until:commit_ish ->
-  t ->
-  after:commit_ish ->
-  ((string * string) list, R.msg) result
-(** [changes r ~after ~until] is the list of commits with their one-line message
-    from commit-ish [after] to commit-ish [until] (defaults to ["HEAD"]). *)
-
-val tracked_files : ?tree_ish:string -> t -> (Fpath.t list, R.msg) result
-(** [tracked_files ~tree_ish r] are the files tracked by the tree object
-    [tree_ish] (defaults to ["HEAD"]). *)
 
 (** {1:ops Repository operations} *)
 
@@ -128,11 +82,6 @@ val checkout :
   (unit, R.msg) result
 (** [checkout r ~branch commit_ish] checks out [commit_ish]. Checks out in a new
     branch [branch] if provided. *)
-
-val commit_files :
-  dry_run:bool -> ?msg:string -> t -> Fpath.t list -> (unit, R.msg) result
-(** [commit_files r ~msg files] commits the file [files] with message [msg] (if
-    unspecified the VCS should prompt). *)
 
 val tag :
   dry_run:bool ->


### PR DESCRIPTION
(Spring cleaning)

Less code to browse, less `grep` results, easier to maintain.