### PR TITLE
Skip documentation publication when opam's `doc` field is missing 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   the error message posted by `dune-release` (#231, @pitag-ha)
 - Error log formatting: avoid unnecessary line-breaks; indent only slightly
   in multi-lines (#234, @pitag-ha)
+- Linting step of `dune-release distrib` does not fail when opam's `doc` field
+  is missing. Do not try to generate nor publish the documentation when opam's
+  `doc` field is missing. (#235, @gpetiot)
 
 ### Deprecated
 

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -37,9 +37,9 @@ let pp_field = Fmt.(styled `Bold string)
    documentation cannot be published. If it is not called explicitly, we can
    skip this step if the `doc` field of the opam file is not set, we do not
    generate nor publish the documentation, except when using a delegate. *)
-let publish_doc ~from_cli ~dry_run ~yes pkg_names pkg =
+let publish_doc ~specific ~dry_run ~yes pkg_names pkg =
   match Pkg.doc_uri pkg with
-  | _ when from_cli -> publish_doc ~dry_run ~yes pkg_names pkg
+  | _ when specific -> publish_doc ~dry_run ~yes pkg_names pkg
   | Error _ | Ok "" -> (
       match Pkg.delegate pkg with
       | Ok (Some _) -> publish_doc ~dry_run ~yes pkg_names pkg
@@ -66,9 +66,12 @@ let publish_alt ~dry_run pkg kind =
   Pkg.publish_msg pkg >>= fun msg ->
   Delegate.publish_alt ~dry_run pkg ~kind ~msg ~archive
 
-let publish ?(from_cli = false) ?build_dir ?opam ?delegate ?change_log
-    ?distrib_uri ?distrib_file ?publish_msg ~name ~pkg_names ~version ~tag
-    ~keep_v ~dry_run ~publish_artefacts ~yes () =
+let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
+    ?publish_msg ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
+    ~publish_artefacts ~yes () =
+  let specific =
+    List.exists (function `Doc -> true | _ -> false) publish_artefacts
+  in
   let publish_artefacts =
     match publish_artefacts with [] -> None | v -> Some v
   in
@@ -80,7 +83,7 @@ let publish ?(from_cli = false) ?build_dir ?opam ?delegate ?change_log
   let publish_artefact acc artefact =
     acc >>= fun () ->
     match artefact with
-    | `Doc -> publish_doc ~from_cli ~dry_run ~yes pkg_names pkg
+    | `Doc -> publish_doc ~specific ~dry_run ~yes pkg_names pkg
     | `Distrib -> publish_distrib ~dry_run ~yes pkg
     | `Alt kind -> publish_alt ~dry_run pkg kind
   in
@@ -92,10 +95,8 @@ let publish_cli () build_dir name pkg_names version tag keep_v opam delegate
     yes =
   publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
     ?publish_msg ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
-    ~publish_artefacts ~yes ~from_cli:true ()
+    ~publish_artefacts ~yes ()
   |> Cli.handle_error
-
-let publish = publish ~from_cli:false
 
 (* Command line interface *)
 

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -88,13 +88,17 @@ let lint_res ~msgf = function
 let pp_field = Fmt.(styled `Bold string)
 
 let lint_opam_doc pkg =
-  ( match Pkg.doc_user_repo_and_path pkg with
-  | Ok _ ->
+  ( match Pkg.doc_uri pkg with
+  | Error _ | Ok "" ->
       report_status `Ok (fun l ->
-          l "opam field %a can be parsed by dune-release" pp_field "doc")
-  | Error _ ->
-      report_status `Fail (fun l ->
-          l "opam field %a can not be parsed by dune-release" pp_field "doc") );
+          l "Skipping doc field linting, no doc field found")
+  | Ok _ ->
+      let pass = R.is_ok (Pkg.doc_user_repo_and_path pkg) in
+      let status = if pass then `Ok else `Fail in
+      let verdict = if pass then "can" else "cannot" in
+      report_status status (fun l ->
+          l "opam field %a %s be parsed by dune-release" pp_field "doc" verdict)
+  );
   0
 
 let lint_opam_home_and_dev pkg =

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -88,10 +88,14 @@ let lint_res ~msgf = function
 let pp_field = Fmt.(styled `Bold string)
 
 let lint_opam_doc pkg =
-  lint_res
-    ~msgf:(fun l ->
-      l "opam field %a can be parsed by dune-release" pp_field "doc")
-    (Pkg.doc_user_repo_and_path pkg)
+  ( match Pkg.doc_user_repo_and_path pkg with
+  | Ok _ ->
+      report_status `Ok (fun l ->
+          l "opam field %a can be parsed by dune-release" pp_field "doc")
+  | Error _ ->
+      report_status `Fail (fun l ->
+          l "opam field %a can not be parsed by dune-release" pp_field "doc") );
+  0
 
 let lint_opam_home_and_dev pkg =
   lint_res

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -47,7 +47,6 @@ type t = {
   distrib_uri : string option;
   distrib_file : Fpath.t option;
   publish_msg : string option;
-  publish_artefacts : [ `Distrib | `Doc | `Alt of string ] list option;
 }
 
 let opam_fields p = Lazy.force p.opam_fields
@@ -377,11 +376,6 @@ let publish_msg p =
       Text.change_log_file_last_entry change_log >>= fun (_, (_, txt)) ->
       Ok (strf "CHANGES:\n\n%s\n" (String.trim txt))
 
-let publish_artefacts p =
-  match p.publish_artefacts with
-  | Some arts -> Ok arts
-  | None -> Ok [ `Doc; `Distrib ]
-
 let infer_from_dune_project dir =
   let file = Fpath.(dir / "dune-project") in
   Bos.OS.File.exists file >>= function
@@ -458,7 +452,7 @@ let infer_name dir =
 
 let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir
     ?opam:opam_file ?opam_descr ?readme ?change_log ?license ?distrib_uri
-    ?distrib_file ?publish_msg ?publish_artefacts ?(distrib = Distrib.v ()) () =
+    ?distrib_file ?publish_msg ?(distrib = Distrib.v ()) () =
   let name =
     match name with None -> infer_name Fpath.(v ".") | Some v -> Ok v
   in
@@ -486,7 +480,6 @@ let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir
       distrib_uri;
       distrib_file;
       publish_msg;
-      publish_artefacts;
       distrib;
     }
   in

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -29,7 +29,6 @@ val v :
   ?distrib_uri:string ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
-  ?publish_artefacts:[ `Distrib | `Doc | `Alt of string ] list ->
   ?distrib:Distrib.t ->
   unit ->
   t
@@ -109,10 +108,6 @@ val archive_url_path : t -> (Fpath.t, R.msg) result
 val distrib_filename : ?opam:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_filename ~opam p] is a distribution filename for [p]. If [opam] is
     [true] (defaults to [false]), the name follows opam's naming conventions. *)
-
-val publish_artefacts :
-  t -> ([ `Distrib | `Doc | `Alt of string ] list, R.msg) result
-(** [publish_artefacts p] are [p]'s publication artefacts. *)
 
 (** {1 Uri} *)
 

--- a/tests/bin/no_doc/dune
+++ b/tests/bin/no_doc/dune
@@ -1,0 +1,3 @@
+(mdx
+ (files run.t)
+ (packages dune-release))

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -20,6 +20,7 @@ We need a basic opam project skeleton
     > homepage: "https://github.com/foo/whatever"\
     > dev-repo: "git+https://github.com/foo/whatever.git"\
     > description: "whatever-lib"\
+    > doc: ""\
     > EOF
     $ touch README
     $ touch LICENSE
@@ -75,7 +76,7 @@ We make a dry-run release
     [ OK ] lint opam file whatever-lib.opam.
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [FAIL] opam field doc can not be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
     [ OK ] lint _build/whatever-0.1.0 success
     => chdir _build/whatever-0.1.0
     => exists ./README
@@ -90,7 +91,7 @@ We make a dry-run release
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [FAIL] opam field doc can not be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
     [ OK ] lint _build/whatever-0.1.0 success
     
     [-] Building package in _build/whatever-0.1.0

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -1,0 +1,90 @@
+We need a basic opam project skeleton
+
+    $ cat > CHANGES.md << EOF \
+    > ## 0.1.0\
+    > \
+    > - Some other feature\
+    > \
+    > ## 0.0.0\
+    > \
+    > - Some feature\
+    > EOF
+    $ cat > whatever.opam << EOF \
+    > opam-version: "2.0"\
+    > homepage: "https://github.com/foo/whatever"\
+    > dev-repo: "git+https://github.com/foo/whatever.git"\
+    > description: "whatever"\
+    > EOF
+    $ touch README
+    $ touch LICENSE
+    $ cat > dune-project << EOF \
+    > (lang dune 2.4)\
+    > (name whatever)\
+    > EOF
+
+We need to set up a git project for dune-release to work properly
+
+    $ git init > /dev/null
+    $ git add CHANGES.md whatever.opam dune-project README LICENSE
+    $ git commit -m "Initial commit" > /dev/null
+    $ dune-release tag -y
+    [-] Extracting tag from first entry in CHANGES.md
+    [-] Using tag "0.1.0"
+    [+] Tagged HEAD with version 0.1.0
+
+We make a dry-run release
+
+    $ dune-release distrib --dry-run
+    [-] Building source archive
+    => rmdir _build/whatever-0.1.0.build
+    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    => exec: git --git-dir .git show -s --format=%ct 0.1.0^{commit}
+    => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
+    => exec:
+         git --git-dir _build/whatever-0.1.0.build/.git --work-tree   _build/whatever-0.1.0.build/ checkout --quiet -b dune-release-dist-0.1.0   0.1.0
+    => chdir _build/whatever-0.1.0.build
+       [in _build/whatever-0.1.0.build]
+    -: exec: dune subst
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-0.1.0.build
+    [+] Wrote archive _build/whatever-0.1.0.tbz
+    => chdir _build/
+       [in _build]
+    => exec: tar -xjf whatever-0.1.0.tbz
+    
+    [-] Linting distrib in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+       [in _build/whatever-0.1.0]
+    => exists ./README
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field description is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [FAIL] opam field doc can be parsed by dune-release
+    dune-release: [ERROR] Could not derive publication directory $PATH from opam
+                          doc field value ""; expected the pattern
+                          $SCHEME://$USER.github.io/$REPO/$PATH
+    [FAIL] lint _build/whatever-0.1.0 failure: 1 errors.
+    
+    [-] Building package in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+    -: exec: dune build -p whatever
+    [ OK ] package builds
+    
+    [-] Running package tests in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+    -: exec: dune runtest -p whatever
+    [ OK ] package tests
+    
+    [+] Distribution for whatever 0.1.0
+    [+] Commit ...
+    [+] Archive _build/whatever-0.1.0.tbz
+    [1]

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -90,8 +90,5 @@ We publish the documentation
 
     $ dune-release publish doc
     [-] Publishing documentation
-    [-] Selected packages: whatever
-    [-] Generating documentation from _build/whatever-0.1.0.tbz
-    [-] Publishing to github
-    dune-release: [ERROR] Could not derive publication directory $PATH from opam doc field value ""; expected the pattern $SCHEME://$USER.github.io/$REPO/$PATH
-    [3]
+    [-] No doc field found for package whatever
+    [-] Skipping

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -15,6 +15,12 @@ We need a basic opam project skeleton
     > dev-repo: "git+https://github.com/foo/whatever.git"\
     > description: "whatever"\
     > EOF
+    $ cat > whatever-lib.opam << EOF \
+    > opam-version: "2.0"\
+    > homepage: "https://github.com/foo/whatever"\
+    > dev-repo: "git+https://github.com/foo/whatever.git"\
+    > description: "whatever-lib"\
+    > EOF
     $ touch README
     $ touch LICENSE
     $ cat > dune-project << EOF \
@@ -25,7 +31,7 @@ We need a basic opam project skeleton
 We need to set up a git project for dune-release to work properly
 
     $ git init > /dev/null
-    $ git add CHANGES.md whatever.opam dune-project README LICENSE
+    $ git add CHANGES.md whatever.opam whatever-lib.opam dune-project README LICENSE
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y
     [-] Extracting tag from first entry in CHANGES.md
@@ -45,6 +51,7 @@ We make a dry-run release
     => chdir _build/whatever-0.1.0.build
        [in _build/whatever-0.1.0.build]
     -: exec: dune subst
+    -: write whatever-lib.opam
     -: write whatever.opam
     => exec: bzip2
     -: rmdir _build/whatever-0.1.0.build
@@ -56,6 +63,21 @@ We make a dry-run release
     [-] Linting distrib in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
        [in _build/whatever-0.1.0]
+    => exists ./README
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever-lib.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever-lib.opam
+    [ OK ] lint opam file whatever-lib.opam.
+    [ OK ] opam field description is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [FAIL] opam field doc can not be parsed by dune-release
+    [ OK ] lint _build/whatever-0.1.0 success
+    => chdir _build/whatever-0.1.0
     => exists ./README
     [ OK ] File README is present.
     => exists ./LICENSE

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -52,8 +52,8 @@ We make a dry-run release
     => chdir _build/whatever-0.1.0.build
        [in _build/whatever-0.1.0.build]
     -: exec: dune subst
-    -: write whatever-lib.opam
-    -: write whatever.opam
+    -: write ...
+    -: write ...
     => exec: bzip2
     -: rmdir _build/whatever-0.1.0.build
     [+] Wrote archive _build/whatever-0.1.0.tbz
@@ -70,10 +70,10 @@ We make a dry-run release
     [ OK ] File LICENSE is present.
     => exists ./CHANGES.md
     [ OK ] File CHANGES is present.
-    => exists whatever-lib.opam
+    => exists ...
     [ OK ] File opam is present.
-    -: exec: opam lint -s whatever-lib.opam
-    [ OK ] lint opam file whatever-lib.opam.
+    -: exec: opam lint -s ...
+    [ OK ] lint opam file ...
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
@@ -85,10 +85,10 @@ We make a dry-run release
     [ OK ] File LICENSE is present.
     => exists ./CHANGES.md
     [ OK ] File CHANGES is present.
-    => exists whatever.opam
+    => exists ...
     [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
+    -: exec: opam lint -s ...
+    [ OK ] lint opam file ...
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
@@ -113,7 +113,7 @@ We publish the documentation, calling publish doc explicitely should fail
 
     $ dune-release publish doc
     [-] Publishing documentation
-    [-] Selected packages: whatever-lib whatever
+    [-] Selected packages: ...
     [-] Generating documentation from _build/whatever-0.1.0.tbz
     [-] Publishing to github
     dune-release: [ERROR] Could not derive publication directory $PATH from opam doc field value ""; expected the pattern $SCHEME://$USER.github.io/$REPO/$PATH
@@ -132,8 +132,8 @@ We do the whole process, calling publish doc implicitely should succeed
     => chdir _build/whatever-0.1.0.build
        [in _build/whatever-0.1.0.build]
     -: exec: dune subst
-    -: write whatever-lib.opam
-    -: write whatever.opam
+    -: write ...
+    -: write ...
     => exec: bzip2
     -: rmdir _build/whatever-0.1.0.build
     [+] Wrote archive _build/whatever-0.1.0.tbz
@@ -151,10 +151,10 @@ We do the whole process, calling publish doc implicitely should succeed
     [ OK ] File LICENSE is present.
     => exists ./CHANGES.md
     [ OK ] File CHANGES is present.
-    => exists whatever-lib.opam
+    => exists ...
     [ OK ] File opam is present.
-    -: exec: opam lint -s whatever-lib.opam
-    [ OK ] lint opam file whatever-lib.opam.
+    -: exec: opam lint -s ...
+    [ OK ] lint opam file ...
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
@@ -166,10 +166,10 @@ We do the whole process, calling publish doc implicitely should succeed
     [ OK ] File LICENSE is present.
     => exists ./CHANGES.md
     [ OK ] File CHANGES is present.
-    => exists whatever.opam
+    => exists ...
     [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
+    -: exec: opam lint -s ...
+    [ OK ] lint opam file ...
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
@@ -198,12 +198,10 @@ We do the whole process, calling publish doc implicitely should succeed
     [?] Push tag 0.1.0 to git@github.com:foo/whatever.git? [Y/n]
     [-] Pushing tag 0.1.0 to git@github.com:foo/whatever.git
     -: exec: git --git-dir .git push --force git@github.com:foo/whatever.git 0.1.0
-    => read /home/gpe/.config/dune/github.token
+    ...
     [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API
-    => read /home/gpe/.config/dune/github.token
-    -: exec: curl -ufoo:7d818f8a015beea0b10c457993002f58097f789f-L-s-S-K--D---data
-         { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n- Some other feature\n" }
+    ...
     dune-release: [ERROR] Could not find release id in response:
     
     [3]

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -112,4 +112,9 @@ We make a dry-run release
 We publish the documentation
 
     $ dune-release publish doc
-    [-] Skipping documentation publication for package whatever: no doc field in whatever.opam
+    [-] Publishing documentation
+    [-] Selected packages: whatever-lib whatever
+    [-] Generating documentation from _build/whatever-0.1.0.tbz
+    [-] Publishing to github
+    dune-release: [ERROR] Could not derive publication directory $PATH from opam doc field value ""; expected the pattern $SCHEME://$USER.github.io/$REPO/$PATH
+    [3]

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -68,11 +68,8 @@ We make a dry-run release
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field description is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [FAIL] opam field doc can be parsed by dune-release
-    dune-release: [ERROR] Could not derive publication directory $PATH from opam
-                          doc field value ""; expected the pattern
-                          $SCHEME://$USER.github.io/$REPO/$PATH
-    [FAIL] lint _build/whatever-0.1.0 failure: 1 errors.
+    [FAIL] opam field doc can not be parsed by dune-release
+    [ OK ] lint _build/whatever-0.1.0 success
     
     [-] Building package in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
@@ -83,8 +80,8 @@ We make a dry-run release
     => chdir _build/whatever-0.1.0
     -: exec: dune runtest -p whatever
     [ OK ] package tests
+    -: rmdir _build/whatever-0.1.0
     
     [+] Distribution for whatever 0.1.0
     [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
-    [1]

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -112,6 +112,4 @@ We make a dry-run release
 We publish the documentation
 
     $ dune-release publish doc
-    [-] Publishing documentation
-    [-] No doc field found for package whatever
-    [-] Skipping
+    [-] Skipping documentation publication for package whatever: no doc field in whatever.opam

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -109,7 +109,7 @@ We make a dry-run release
     [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
 
-We publish the documentation
+We publish the documentation, calling publish doc explicitely should fail
 
     $ dune-release publish doc
     [-] Publishing documentation
@@ -117,4 +117,93 @@ We publish the documentation
     [-] Generating documentation from _build/whatever-0.1.0.tbz
     [-] Publishing to github
     dune-release: [ERROR] Could not derive publication directory $PATH from opam doc field value ""; expected the pattern $SCHEME://$USER.github.io/$REPO/$PATH
+    [3]
+
+We do the whole process, calling publish doc implicitely should succeed
+
+    $  yes | dune-release --dry-run
+    [-] Building source archive
+    => rmdir _build/whatever-0.1.0.build
+    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    => exec: git --git-dir .git show -s --format=%ct 0.1.0^{commit}
+    => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
+    => exec:
+         git --git-dir _build/whatever-0.1.0.build/.git --work-tree   _build/whatever-0.1.0.build/ checkout --quiet -b dune-release-dist-0.1.0   0.1.0
+    => chdir _build/whatever-0.1.0.build
+       [in _build/whatever-0.1.0.build]
+    -: exec: dune subst
+    -: write whatever-lib.opam
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-0.1.0.build
+    [+] Wrote archive _build/whatever-0.1.0.tbz
+    => chdir _build/
+       [in _build]
+    => rmdir _build/whatever-0.1.0
+    => exec: tar -xjf whatever-0.1.0.tbz
+    
+    [-] Linting distrib in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+       [in _build/whatever-0.1.0]
+    => exists ./README
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever-lib.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever-lib.opam
+    [ OK ] lint opam file whatever-lib.opam.
+    [ OK ] opam field description is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint _build/whatever-0.1.0 success
+    => chdir _build/whatever-0.1.0
+    => exists ./README
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field description is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint _build/whatever-0.1.0 success
+    
+    [-] Building package in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+    -: exec: dune build -p whatever
+    [ OK ] package builds
+    
+    [-] Running package tests in _build/whatever-0.1.0
+    => chdir _build/whatever-0.1.0
+    -: exec: dune runtest -p whatever
+    [ OK ] package tests
+    -: rmdir _build/whatever-0.1.0
+    
+    [+] Distribution for whatever 0.1.0
+    [+] Commit ...
+    [+] Archive _build/whatever-0.1.0.tbz
+    [-] Skipping documentation publication for package whatever: no doc field in whatever.opam
+    [-] Publishing distribution
+    => must exists _build/whatever-0.1.0.tbz
+    [-] Publishing to github
+    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    [?] Push tag 0.1.0 to git@github.com:foo/whatever.git? [Y/n]
+    [-] Pushing tag 0.1.0 to git@github.com:foo/whatever.git
+    -: exec: git --git-dir .git push --force git@github.com:foo/whatever.git 0.1.0
+    => read /home/gpe/.config/dune/github.token
+    [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
+    [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API
+    => read /home/gpe/.config/dune/github.token
+    -: exec: curl -ufoo:7d818f8a015beea0b10c457993002f58097f789f-L-s-S-K--D---data
+         { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n- Some other feature\n" }
+    dune-release: [ERROR] Could not find release id in response:
+    
     [3]

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -85,3 +85,13 @@ We make a dry-run release
     [+] Distribution for whatever 0.1.0
     [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
+
+We publish the documentation
+
+    $ dune-release publish doc
+    [-] Publishing documentation
+    [-] Selected packages: whatever
+    [-] Generating documentation from _build/whatever-0.1.0.tbz
+    [-] Publishing to github
+    dune-release: [ERROR] Could not derive publication directory $PATH from opam doc field value ""; expected the pattern $SCHEME://$USER.github.io/$REPO/$PATH
+    [3]


### PR DESCRIPTION
Fix #149