### PR TITLE
Use long names for curl options and document their usage

### DIFF
--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -2,6 +2,8 @@ open Bos_setup
 
 type t = { url : string; args : string list }
 
+type auth = { user : string; token : string }
+
 let escape_for_json s =
   let len = String.length s in
   let max = len - 1 in
@@ -39,13 +41,56 @@ let escape_for_json s =
     in
     loop 0 0
 
+module Options = struct
+  (* If the server reports that the requested page has moved to a different
+     location, this option will make curl redo the request on the new place. *)
+  let location args = "--location" :: args
+
+  (* Specify the user name and password to use for server authentication. *)
+  let user { user; token } args = "--user" :: strf "%s:%s" user token :: args
+
+  (* Silent or quiet mode. Don't show progress meter or error messages. Makes
+     Curl mute. It will still output the data you ask for, potentially even to
+     the terminal/stdout unless you redirect it. *)
+  let silent args = "--silent" :: args
+
+  (* When used with -s, --silent, it makes curl show an error message if it
+     fails. *)
+  let show_error args = "--show-error" :: args
+
+  (* Specify a text file to read curl arguments from. The command line
+     arguments found in the text file will be used as if they were provided on
+     the command line.
+     Specify the filename to -K, --config as '-' to make curl read the file
+     from stdin. *)
+  let config file args = "--config" :: file :: args
+
+  (* Write the received protocol headers to the specified file. *)
+  let dump_header file args = "--dump-header" :: file :: args
+
+  (* Sends the specified data in a POST request to the HTTP server. If the data
+     starts with the letter @, the rest should be a filename. *)
+  let data data args = "--data" :: data :: args
+
+  (* This posts data exactly as specified with no extra processing whatsoever.
+     If the data starts with the letter @, the rest should be a filename. *)
+  let data_binary data args = "--data-binary" :: data :: args
+
+  (* Extra header to include in the request when sending HTTP to a server. *)
+  let header header args = "--header" :: header :: args
+end
+
 let create_release ~version ~msg ~user ~repo =
-  let data =
+  let json =
     strf "{ \"tag_name\" : \"%s\", \"body\" : \"%s\" }"
       (escape_for_json version) (escape_for_json msg)
   in
   let url = strf "https://api.github.com/repos/%s/%s/releases" user repo in
-  let args = [ "-L"; "-s"; "-S"; "-K"; "-"; "-D"; "-"; "--data"; data ] in
+  let args =
+    let open Options in
+    location @@ silent @@ show_error @@ config "-" @@ dump_header "-"
+    @@ data json @@ []
+  in
   { url; args }
 
 let upload_archive ~archive ~user ~repo ~release_id =
@@ -54,30 +99,25 @@ let upload_archive ~archive ~user ~repo ~release_id =
       user repo release_id (Fpath.filename archive)
   in
   let args =
-    [
-      "-L";
-      "-s";
-      "-S";
-      "-K";
-      "-";
-      "-D";
-      "-";
-      "-H";
-      "Content-Type:application/x-tar";
-      "--data-binary";
-      strf "@@%s" (Fpath.to_string archive);
-    ]
+    let open Options in
+    location @@ silent @@ show_error @@ config "-" @@ dump_header "-"
+    @@ header "Content-Type:application/x-tar"
+    @@ data_binary (strf "@@%s" (Fpath.to_string archive))
+    @@ []
   in
   { url; args }
 
 let open_pr ~title ~user ~branch ~body ~opam_repo =
   let base, repo = opam_repo in
   let url = strf "https://api.github.com/repos/%s/%s/pulls" base repo in
-  let data =
+  let json =
     strf {|{"title": %S,"base": "master", "body": %S, "head": "%s:%s"}|} title
       body user branch
   in
-  let args = [ "-s"; "-S"; "-K"; "-"; "-D"; "-"; "--data"; data ] in
+  let args =
+    let open Options in
+    silent @@ show_error @@ config "-" @@ dump_header "-" @@ data json @@ []
+  in
   { url; args }
 
-let with_auth ~auth { url; args } = { url; args = "-u" :: auth :: args }
+let with_auth ~auth { url; args } = { url; args = Options.user auth args }

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -1,6 +1,4 @@
-type t = { url : string; args : string list }
-
-type auth = { user : string; token : string }
+type t = { url : string; args : Curl_option.t list }
 
 val create_release :
   version:string -> msg:string -> user:string -> repo:string -> t
@@ -16,4 +14,4 @@ val open_pr :
   opam_repo:string * string ->
   t
 
-val with_auth : auth:auth -> t -> t
+val with_auth : auth:Curl_option.auth -> t -> t

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -1,5 +1,7 @@
 type t = { url : string; args : string list }
 
+type auth = { user : string; token : string }
+
 val create_release :
   version:string -> msg:string -> user:string -> repo:string -> t
 
@@ -14,4 +16,4 @@ val open_pr :
   opam_repo:string * string ->
   t
 
-val with_auth : auth:string -> t -> t
+val with_auth : auth:auth -> t -> t

--- a/lib/curl_option.ml
+++ b/lib/curl_option.ml
@@ -1,0 +1,32 @@
+open Astring
+
+type auth = { user : string; token : string }
+
+type t =
+  | Location
+  | User of auth
+  | Silent
+  | Show_error
+  | Config of [ `Stdin | `File of string ]
+  | Dump_header of [ `Ignore | `File of string ]
+  | Data of [ `Data of string | `File of string ]
+  | Data_binary of [ `Data of string | `File of string ]
+  | Header of string
+
+let to_string_list opts =
+  List.fold_left
+    (fun acc -> function Location -> "--location" :: acc
+      | User { user; token } -> "--user" :: strf "%s:%s" user token :: acc
+      | Silent -> "--silent" :: acc | Show_error -> "--show-error" :: acc
+      | Config `Stdin -> "--config" :: "-" :: acc
+      | Config (`File f) -> "--config" :: f :: acc
+      | Dump_header `Ignore -> "--dump-header" :: "-" :: acc
+      | Dump_header (`File f) -> "--dump-header" :: f :: acc
+      | Data (`Data d) -> "--data" :: d :: acc
+      (* Filenames should start with the letter [@]. *)
+      | Data (`File f) -> "--data" :: strf "@@%s" f :: acc
+      | Data_binary (`Data d) -> "--data-binary" :: d :: acc
+      (* Filenames should start with the letter [@]. *)
+      | Data_binary (`File f) -> "--data-binary" :: strf "@@%s" f :: acc
+      | Header h -> "--header" :: h :: acc)
+    [] (List.rev opts)

--- a/lib/curl_option.mli
+++ b/lib/curl_option.mli
@@ -1,0 +1,31 @@
+type auth = { user : string; token : string }
+
+type t =
+  | Location
+      (** If the server reports that the requested page has moved to a different
+          location, this option will make curl redo the request on the new
+          place. *)
+  | User of auth
+      (** Specify the user name and password for server authentication. *)
+  | Silent
+      (** Silent or quiet mode. Don't show progress meter or error messages.
+          Makes Curl mute. It will still output the data you ask for,
+          potentially even to the terminal/stdout unless you redirect it. *)
+  | Show_error
+      (** When used with -s, --silent, it makes curl show an error message if it
+          fails. *)
+  | Config of [ `Stdin | `File of string ]
+      (** Specify a text file to read curl arguments from. The command line
+          arguments found in the text file will be used as if they were provided
+          on the command line. *)
+  | Dump_header of [ `Ignore | `File of string ]
+      (** Write the received protocol headers to the specified file. *)
+  | Data of [ `Data of string | `File of string ]
+      (** Sends the specified data in a POST request to the HTTP server. *)
+  | Data_binary of [ `Data of string | `File of string ]
+      (** This posts data exactly as specified with no extra processing
+          whatsoever. *)
+  | Header of string
+      (** Extra header to include in the request when sending HTTP. *)
+
+val to_string_list : t list -> string list

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -161,9 +161,8 @@ let publish_doc ~dry_run ~msg:_ ~docdir ~yes p =
 (* Publish releases *)
 
 let github_auth ~dry_run ~user token =
-  if dry_run then Ok (strf "%s:%s" user D.token)
-  else
-    Sos.read_file ~dry_run token >>= fun token -> Ok (strf "%s:%s" user token)
+  if dry_run then Ok Curl.{ user; token = D.token }
+  else Sos.read_file ~dry_run token >>| fun token -> Curl.{ user; token }
 
 let run_with_auth ?(default_body = `Null) ~dry_run ~auth curl_t =
   let Curl.{ url; args } = Curl.with_auth ~auth curl_t in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -161,11 +161,12 @@ let publish_doc ~dry_run ~msg:_ ~docdir ~yes p =
 (* Publish releases *)
 
 let github_auth ~dry_run ~user token =
-  if dry_run then Ok Curl.{ user; token = D.token }
-  else Sos.read_file ~dry_run token >>| fun token -> Curl.{ user; token }
+  if dry_run then Ok Curl_option.{ user; token = D.token }
+  else Sos.read_file ~dry_run token >>| fun token -> Curl_option.{ user; token }
 
 let run_with_auth ?(default_body = `Null) ~dry_run ~auth curl_t =
   let Curl.{ url; args } = Curl.with_auth ~auth curl_t in
+  let args = Curl_option.to_string_list args in
   if dry_run then
     Sos.show "exec:@[@ curl %a@]"
       Format.(pp_print_list ~pp_sep:pp_print_space pp_print_string)

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -202,7 +202,8 @@ We do the whole process, calling publish doc implicitely should succeed
     [?] Create release 0.1.0 on git@github.com:foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on git@github.com:foo/whatever.git via github's API
     ...
-    -: exec: curl -u foo:${token} -L -s -S -K - -D - --data
+    -: exec: curl --user foo:${token} --location --silent --show-error --config -
+         --dump-header - --data
          { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n- Some other feature\n" }
     dune-release: [ERROR] Could not retrieve release ID from response
     [3]

--- a/tests/lib/alcotest_ext.ml
+++ b/tests/lib/alcotest_ext.ml
@@ -12,6 +12,7 @@ let opam_version =
 
 let curl =
   let pp fs Dune_release.Curl.{ url; args } =
+    let args = Dune_release.Curl_option.to_string_list args in
     Format.fprintf fs "url = %S;@ " url;
     Format.fprintf fs "args = %a@\n" (Fmt.list ~sep:Fmt.sp Fmt.string) args
   in

--- a/tests/lib/alcotest_ext.ml
+++ b/tests/lib/alcotest_ext.ml
@@ -12,7 +12,7 @@ let opam_version =
 
 let curl =
   let pp fs Dune_release.Curl.{ url; args } =
-    Fmt.string fs url;
-    Fmt.list Fmt.string fs args
+    Format.fprintf fs "url = %S;@ " url;
+    Format.fprintf fs "args = %a@\n" (Fmt.list ~sep:Fmt.sp Fmt.string) args
   in
   testable pp ( = )

--- a/tests/lib/test_curl.ml
+++ b/tests/lib/test_curl.ml
@@ -14,12 +14,12 @@ let test_create_release =
           url = "https://api.github.com/repos/you/some-repo/releases";
           args =
             [
-              "-L";
-              "-s";
-              "-S";
-              "-K";
+              "--location";
+              "--silent";
+              "--show-error";
+              "--config";
               "-";
-              "-D";
+              "--dump-header";
               "-";
               "--data";
               {|{ "tag_name" : "1.1.0", "body" : "this is a message" }|};
@@ -47,14 +47,14 @@ let test_upload_archive =
             "https://uploads.github.com/repos/you/some-repo/releases/27/assets?name=foo.tgz";
           args =
             [
-              "-L";
-              "-s";
-              "-S";
-              "-K";
+              "--location";
+              "--silent";
+              "--show-error";
+              "--config";
               "-";
-              "-D";
+              "--dump-header";
               "-";
-              "-H";
+              "--header";
               "Content-Type:application/x-tar";
               "--data-binary";
               "@foo.tgz";
@@ -82,11 +82,11 @@ let test_open_pr =
           url = "https://api.github.com/repos/base/repo/pulls";
           args =
             [
-              "-s";
-              "-S";
-              "-K";
+              "--silent";
+              "--show-error";
+              "--config";
               "-";
-              "-D";
+              "--dump-header";
               "-";
               "--data";
               {|{"title": "This is a PR","base": "master", "body": "This PR fixes everything.\nThis is the best PR.\n", "head": "you:my-best-pr"}|};
@@ -95,7 +95,7 @@ let test_open_pr =
   ]
 
 let test_with_auth =
-  let auth = "foooooooooooo" in
+  let auth = Dune_release.Curl.{ user = "foo"; token = "bar" } in
   let make_test ~test_name ~curl_t ~expected =
     let test_fun () =
       let actual = Dune_release.Curl.with_auth ~auth curl_t in
@@ -108,12 +108,12 @@ let test_with_auth =
       ~curl_t:
         {
           url = "https://api.github.com/repos/base/repo/pulls";
-          args = [ "-s"; "-S"; "-K"; "-"; "-D"; "-" ];
+          args = [ "--config"; "-"; "--dump-header"; "-" ];
         }
       ~expected:
         {
           url = "https://api.github.com/repos/base/repo/pulls";
-          args = [ "-u"; auth; "-s"; "-S"; "-K"; "-"; "-D"; "-" ];
+          args = [ "--user"; "foo:bar"; "--config"; "-"; "--dump-header"; "-" ];
         };
   ]
 

--- a/tests/lib/test_curl.ml
+++ b/tests/lib/test_curl.ml
@@ -14,15 +14,14 @@ let test_create_release =
           url = "https://api.github.com/repos/you/some-repo/releases";
           args =
             [
-              "--location";
-              "--silent";
-              "--show-error";
-              "--config";
-              "-";
-              "--dump-header";
-              "-";
-              "--data";
-              {|{ "tag_name" : "1.1.0", "body" : "this is a message" }|};
+              Location;
+              Silent;
+              Show_error;
+              Config `Stdin;
+              Dump_header `Ignore;
+              Data
+                (`Data
+                  {|{ "tag_name" : "1.1.0", "body" : "this is a message" }|});
             ];
         };
   ]
@@ -47,17 +46,13 @@ let test_upload_archive =
             "https://uploads.github.com/repos/you/some-repo/releases/27/assets?name=foo.tgz";
           args =
             [
-              "--location";
-              "--silent";
-              "--show-error";
-              "--config";
-              "-";
-              "--dump-header";
-              "-";
-              "--header";
-              "Content-Type:application/x-tar";
-              "--data-binary";
-              "@foo.tgz";
+              Location;
+              Silent;
+              Show_error;
+              Config `Stdin;
+              Dump_header `Ignore;
+              Header "Content-Type:application/x-tar";
+              Data_binary (`File "foo.tgz");
             ];
         };
   ]
@@ -82,20 +77,19 @@ let test_open_pr =
           url = "https://api.github.com/repos/base/repo/pulls";
           args =
             [
-              "--silent";
-              "--show-error";
-              "--config";
-              "-";
-              "--dump-header";
-              "-";
-              "--data";
-              {|{"title": "This is a PR","base": "master", "body": "This PR fixes everything.\nThis is the best PR.\n", "head": "you:my-best-pr"}|};
+              Silent;
+              Show_error;
+              Config `Stdin;
+              Dump_header `Ignore;
+              Data
+                (`Data
+                  {|{"title": "This is a PR","base": "master", "body": "This PR fixes everything.\nThis is the best PR.\n", "head": "you:my-best-pr"}|});
             ];
         };
   ]
 
 let test_with_auth =
-  let auth = Dune_release.Curl.{ user = "foo"; token = "bar" } in
+  let auth = Dune_release.Curl_option.{ user = "foo"; token = "bar" } in
   let make_test ~test_name ~curl_t ~expected =
     let test_fun () =
       let actual = Dune_release.Curl.with_auth ~auth curl_t in
@@ -108,12 +102,12 @@ let test_with_auth =
       ~curl_t:
         {
           url = "https://api.github.com/repos/base/repo/pulls";
-          args = [ "--config"; "-"; "--dump-header"; "-" ];
+          args = [ Config `Stdin; Dump_header `Ignore ];
         }
       ~expected:
         {
           url = "https://api.github.com/repos/base/repo/pulls";
-          args = [ "--user"; "foo:bar"; "--config"; "-"; "--dump-header"; "-" ];
+          args = [ User auth; Config `Stdin; Dump_header `Ignore ];
         };
   ]
 


### PR DESCRIPTION
as discussed in #177 

From reading the `curl` documentation it's not obvious to me whether the `--config` option is necessary, does someone has more experience with it?
I don't think we need to add a changelog entry for this PR.