### PR TITLE
Upgrade to ocamlformat 0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.14.2
+version=0.15.0
 profile=conventional
 parse-docstrings=true


### PR DESCRIPTION
Hi, this is what the project would look like after being reformated with the current version (candidate) of ocamlformat 0.15.0.
**Please do not merge until ocamlformat.0.15.0 is available with opam.**

The main changes are due to the improved inconsistency of option `indicate-multiline-delimiters`, a lot of spaces where missing before closing parentheses in the previous versions.
Please let me know if you see any regressions that I may have missed.