### PR TITLE
Update the changelog file for the 1.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,28 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+## 1.4.0 (2020-07-13)
+
+### Added
+
 - Add a `dune-release config` subcommand to display and edit the global
   configuration (#220, @NathanReb).
 - Add command `delegate-info` to print information needed by external
   release scripts (#221, @pitag-ha)
 - Use Curly instead of Cmd to interact with github (#202, @gpetiot)
 - Add `x-commit-hash` field to the opam file when releasing (#224, @gpetiot)
+- Add support for common alternative names for the license and 
+  ChangeLog file (#204, @paurkedal)
 
 ### Changed
 
@@ -42,6 +58,7 @@
   (#177, @gpetiot)
 - The `git` command used in `publish doc` should check `DUNE_RELEASE_GIT` (even
   if deprecated) before `PATH`. (#242, @gpetiot)
+- Adapt the docs to the removal of the `log` subcommand (#196, @gpetiot)
 
 ### Removed
 


### PR DESCRIPTION
This commit adds an entry for the two PR's since release 1.3.3 that have influenced the behavior but didn't have a changelog entry yet. Furthermore, it adapts the changelog to the 1.4.0 release.