### PR TITLE
Fix a couple bugs in opam pkg subcommand with --dist-file and --dist-uri

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 - Fix the priority of the `--distrib-uri` option in `dune-release opam pkg`.
   It used to have lower precendence than the url file written by `dune-release publish`
   and therefore made it impossible to overwrite it if needed. (#255, @NathanReb)
+- Fix a bug with --distrib-file in `dune-release opam pkg` where you would need
+  the regular dune-release generated archive to be around even though you specified
+  a custom distrib archive file. (#255, @NathanReb)
 
 ### Security
 
@@ -26,7 +29,7 @@
   release scripts (#221, @pitag-ha)
 - Use Curly instead of Cmd to interact with github (#202, @gpetiot)
 - Add `x-commit-hash` field to the opam file when releasing (#224, @gpetiot)
-- Add support for common alternative names for the license and 
+- Add support for common alternative names for the license and
   ChangeLog file (#204, @paurkedal)
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,21 @@
+## unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fix the priority of the `--distrib-uri` option in `dune-release opam pkg`.
+  It used to have lower precendence than the url file written by `dune-release publish`
+  and therefore made it impossible to overwrite it if needed. (#255, @NathanReb)
+
+### Security
+
 ## 1.4.0 (2020-07-13)
 
 ### Added

--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -17,7 +17,7 @@ let bistro () dry_run name pkg_names version tag keep_v =
       >>= fun _publish_ret ->
       Opam.get_pkgs ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
       >>= fun pkgs ->
-      Opam.pkg ~dry_run ~pkgs >>= fun _opam_pkg_ret ->
+      Opam.pkg ~dry_run ~pkgs () >>= fun _opam_pkg_ret ->
       Opam.submit ~dry_run ~pkgs ~pkg_names ~no_auto_open:false ~yes:false ()
       >>= fun _opam_submit_ret -> Ok 0 )
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -239,7 +239,7 @@ let get_pkgs ?build_dir ?opam ?distrib_file ?readme ?change_log ?publish_msg
     let pkg =
       Pkg.v ?name ?opam ?tag ?version ?distrib_file ~dry_run:false ~keep_v ()
     in
-    Pkg.distrib_archive_path pkg
+    Pkg.distrib_file ~dry_run pkg
   in
   Pkg.infer_pkg_names Fpath.(v ".") pkg_names >>= fun pkg_names ->
   let pkg_names = List.map (fun n -> Some n) pkg_names in

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -66,7 +66,7 @@ let archive_url ~dry_run ~opam_file pkg =
           uri);
     Ok uri )
 
-let pkg ~dry_run pkg =
+let pkg ~dry_run ~distrib_uri pkg =
   let warn_if_vcs_dirty () =
     Cli.warn_if_vcs_dirty
       "The opam package may be inconsistent with the distribution."
@@ -77,7 +77,10 @@ let pkg ~dry_run pkg =
   get_pkg_dir pkg >>= fun dir ->
   Pkg.opam pkg >>= fun opam_f ->
   Pkg.distrib_file ~dry_run pkg >>= fun distrib_file ->
-  archive_url ~dry_run ~opam_file:opam_f pkg >>= fun uri ->
+  ( match distrib_uri with
+  | Some uri -> Ok uri
+  | None -> archive_url ~dry_run ~opam_file:opam_f pkg )
+  >>= fun uri ->
   Opam.Url.with_distrib_file ~dry_run ~uri distrib_file >>= fun url ->
   OS.Dir.exists dir >>= fun exists ->
   (if exists then Sos.delete_dir ~dry_run dir else Ok ()) >>= fun () ->
@@ -229,13 +232,12 @@ let field pkgs field =
 
 (* Command *)
 
-let get_pkgs ?build_dir ?opam ?distrib_uri ?distrib_file ?readme ?change_log
-    ?publish_msg ?pkg_descr ~dry_run ~keep_v ~tag ~name ~pkg_names ~version () =
+let get_pkgs ?build_dir ?opam ?distrib_file ?readme ?change_log ?publish_msg
+    ?pkg_descr ~dry_run ~keep_v ~tag ~name ~pkg_names ~version () =
   Config.keep_v keep_v >>= fun keep_v ->
   let distrib_file =
     let pkg =
-      Pkg.v ?name ?opam ?tag ?version ?distrib_file ?distrib_uri ~dry_run:false
-        ~keep_v ()
+      Pkg.v ?name ?opam ?tag ?version ?distrib_file ~dry_run:false ~keep_v ()
     in
     Pkg.distrib_archive_path pkg
   in
@@ -245,15 +247,15 @@ let get_pkgs ?build_dir ?opam ?distrib_uri ?distrib_file ?readme ?change_log
   List.map
     (fun name ->
       Pkg.v ~dry_run ?build_dir ?name ?version ?opam ?tag ?opam_descr:pkg_descr
-        ~keep_v ?distrib_uri ~distrib_file ?readme ?change_log ?publish_msg ())
+        ~keep_v ~distrib_file ?readme ?change_log ?publish_msg ())
     pkg_names
 
 let descr ~pkgs = descr pkgs
 
-let pkg ~dry_run ~pkgs =
+let pkg ?distrib_uri ~dry_run ~pkgs () =
   List.fold_left
     (fun acc p ->
-      match (acc, pkg ~dry_run p) with
+      match (acc, pkg ~dry_run ~distrib_uri p) with
       | Ok i, Ok () -> Ok i
       | (Error _ as e), _ | _, (Error _ as e) -> e)
     (Ok 0) pkgs
@@ -289,12 +291,12 @@ let field ~pkgs ~field_name = field pkgs field_name
 let opam_cli () dry_run build_dir local_repo remote_repo opam_repo user keep_v
     opam distrib_uri distrib_file tag name pkg_names version pkg_descr readme
     change_log publish_msg action field_name no_auto_open yes =
-  get_pkgs ?build_dir ?opam ?distrib_uri ?distrib_file ?pkg_descr ?readme
-    ?change_log ?publish_msg ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
+  get_pkgs ?build_dir ?opam ?distrib_file ?pkg_descr ?readme ?change_log
+    ?publish_msg ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
   >>= (fun pkgs ->
         match action with
         | `Descr -> descr ~pkgs
-        | `Pkg -> pkg ~dry_run ~pkgs
+        | `Pkg -> pkg ~dry_run ?distrib_uri ~pkgs ()
         | `Submit ->
             submit ?local_repo ?remote_repo ?opam_repo ?user ~dry_run ~pkgs
               ~pkg_names ~no_auto_open ~yes ()

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -9,7 +9,6 @@
 val get_pkgs :
   ?build_dir:Fpath.t ->
   ?opam:Fpath.t ->
-  ?distrib_uri:string ->
   ?distrib_file:Fpath.t ->
   ?readme:Fpath.t ->
   ?change_log:Fpath.t ->
@@ -33,7 +32,11 @@ val descr : pkgs:Dune_release.Pkg.t list -> (int, Bos_setup.R.msg) result
     exit code (0 for success, 1 for failure) or error messages. *)
 
 val pkg :
-  dry_run:bool -> pkgs:Dune_release.Pkg.t list -> (int, Bos_setup.R.msg) result
+  ?distrib_uri:string ->
+  dry_run:bool ->
+  pkgs:Dune_release.Pkg.t list ->
+  unit ->
+  (int, Bos_setup.R.msg) result
 (** [pkg ~dry_run ~pkgs] creates the opam package descriptions for packages
     [pkgs] and upgrades them to opam 2.0 if necessary. Returns the exit code (0
     for success, 1 for failure) or error messages. *)

--- a/tests/bin/opam-pkg-distrib-file-opt/dune
+++ b/tests/bin/opam-pkg-distrib-file-opt/dune
@@ -1,0 +1,3 @@
+(mdx
+ (files run.t)
+ (packages dune-release))

--- a/tests/bin/opam-pkg-distrib-file-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-file-opt/run.t
@@ -1,0 +1,41 @@
+We need a basic opam project skeleton
+
+    $ cat > CHANGES.md << EOF \
+    > ## 0.1.0\
+    > \
+    > - Some other feature\
+    > \
+    > ## 0.0.0\
+    > \
+    > - Some feature\
+    > EOF
+    $ cat > whatever.opam << EOF \
+    > opam-version: "2.0" \
+    > EOF
+    $ cat > dune-project << EOF \
+    > (lang dune 2.4)\
+    > (name whatever)\
+    > EOF
+
+We need to set up a git project for dune-release to work properly
+
+    $ git init > /dev/null
+    $ git add CHANGES.md whatever.opam dune-project
+    $ git commit -m "Initial commit" > /dev/null
+
+We want to use our custom distribution archive instead of the one dune-release would have
+generated:
+
+  $ touch our-custom-distrib.tbz
+
+Running the following should not fail if the dune-release generated tarball
+(i.e. here _build/whatever-0.1.0.tbz) is not present:
+
+  $ dune-release opam pkg \
+  > --dist-file ./our-custom-distrib.tbz \
+  > --dist-uri "https://my.custom.url/mytarball.tbz" \
+  > --pkg-version 0.1.0
+  [-] Creating opam package description for whatever
+  [+] Wrote opam package description _build/whatever.0.1.0/opam
+  dune-release: [WARNING] The repo is dirty. The opam package may be
+                          inconsistent with the distribution.

--- a/tests/bin/opam-pkg-distrib-uri-opt/dune
+++ b/tests/bin/opam-pkg-distrib-uri-opt/dune
@@ -1,0 +1,3 @@
+(mdx
+ (files run.t)
+ (packages dune-release))

--- a/tests/bin/opam-pkg-distrib-uri-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-uri-opt/run.t
@@ -1,0 +1,42 @@
+We need a basic opam project skeleton
+
+    $ cat > CHANGES.md << EOF \
+    > ## 0.1.0\
+    > \
+    > - Some other feature\
+    > \
+    > ## 0.0.0\
+    > \
+    > - Some feature\
+    > EOF
+    $ cat > whatever.opam << EOF \
+    > opam-version: "2.0" \
+    > EOF
+    $ cat > dune-project << EOF \
+    > (lang dune 2.4)\
+    > (name whatever)\
+    > EOF
+
+We need to set up a git project for dune-release to work properly
+
+    $ git init > /dev/null
+    $ git add CHANGES.md whatever.opam dune-project
+    $ git commit -m "Initial commit" > /dev/null
+
+We also need a dummy distrib file to keep the test simple:
+
+  $ mkdir _build
+  $ touch _build/whatever-0.1.0.tbz
+
+And a url file as if we just successfully ran dune-release publish distrib:
+
+  $ echo "https://some.fake.url/mytarball.tbz" > _build/whatever-0.1.0.url
+
+Running the following should use the --dist-uri url even if the .url file is present:
+
+  $ dune-release opam pkg \
+  > --dist-uri "https://my.custom.url/mytarball.tbz" \
+  > --pkg-version 0.1.0 \
+  > > /dev/null 2>&1
+  $ cat _build/whatever.0.1.0/opam | grep "mytarball.tbz"
+    src: "https://my.custom.url/mytarball.tbz"


### PR DESCRIPTION
The option used to have lower priority than the recently introduced `url_file` which made it impossible to overwrite it if you wanted to publish the tarball to github and somewhere else but wanted to use the URL for the second one in opam.

I think it's a side effect of the `Pkg` module which contains more than it really should. We should try to fix this as we go.
Actually now that I think of it I'll add a commit that gets rid of the corresponding field in `Pkg.t` since it's not used anymore.