### PR TITLE
Use int64 for timestamps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix a bug with --distrib-file in `dune-release opam pkg` where you would need
   the regular dune-release generated archive to be around even though you specified
   a custom distrib archive file. (#255, @NathanReb)
+- Use int64 for timestamps. (#261, @gpetiot)
 
 ### Security
 

--- a/lib/archive.mli
+++ b/lib/archive.mli
@@ -14,7 +14,7 @@ val tar :
   Fpath.t ->
   exclude_paths:Fpath.set ->
   root:Fpath.t ->
-  mtime:int ->
+  mtime:int64 ->
   (string, R.msg) result
 (** [tar dir ~exclude_paths ~root ~mtime] is a (us)tar archive that contains the
     file hierarchy [dir] except the relative hierarchies present in

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -88,7 +88,7 @@ let git_commit_ptime_s ~dry_run r commit_ish =
   let time = Cmd.(v "show" % "-s" % "--format=%ct" % commit_ish) in
   run_git ~dry_run ~force:true r time ~default:Default.string OS.Cmd.out_string
   >>= fun ptime ->
-  try Ok (int_of_string ptime)
+  try Ok (Int64.of_string ptime)
   with Failure e ->
     R.error_msgf "Could not parse timestamp from %S: %s" ptime e
 
@@ -186,12 +186,12 @@ let hg_commit_ptime_s r ~rev =
     Cmd.(v "log" % "--template" % "'{date(date, \"%s\")}'" % "--rev" % rev)
   in
   run_hg r time OS.Cmd.out_string >>= fun ptime ->
-  try Ok (int_of_string ptime)
+  try Ok (Int64.of_string ptime)
   with Failure _ -> R.error_msgf "Could not parse timestamp from %S" ptime
 
 let hg_describe ~dirty r ~rev =
   let get_distance s =
-    try Ok (int_of_string s)
+    try Ok (Int64.of_string s)
     with Failure _ ->
       R.error_msgf "%a: Could not parse hg tag distance." Fpath.pp (dir r)
   in
@@ -201,7 +201,7 @@ let hg_describe ~dirty r ~rev =
       OS.Cmd.out_string
   in
   (parent "{latesttagdistance}" >>= get_distance >>= function
-   | 1 -> parent "{latesttag}"
+   | 1L -> parent "{latesttag}"
    | _ -> parent "{latesttag}-{latesttagdistance}-{node|short}")
   >>= fun descr ->
   match dirty with

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -42,7 +42,7 @@ val commit_id :
     working tree is dirty. *)
 
 val commit_ptime_s :
-  dry_run:bool -> ?commit_ish:commit_ish -> t -> (int, R.msg) result
+  dry_run:bool -> ?commit_ish:commit_ish -> t -> (int64, R.msg) result
 (** [commit_ptime_s t ~commit_ish] is the POSIX time in seconds of commit
     [commit_ish] (defaults to ["HEAD"]) of repository [r]. *)
 


### PR DESCRIPTION
Trying to fix the `dune-release: [ERROR] Could not parse timestamp from "1596471536": int_of_string` errors we get on debian-10-4.10_arm32 and debian-10-4.10_x86_32