### PR TITLE
Sanitize usage of distrib_uri

### DIFF
--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -169,8 +169,8 @@ let open_pr ~dry_run ~changes ~remote_repo ~user ~distrib_user ~branch ~token
         | Ok () -> Ok 0
         | Error _ -> msg () )
 
-let submit ~token ~dry_run ~yes ~opam_repo ~user local_repo remote_repo pkgs
-    auto_open =
+let submit ?distrib_uri ~token ~dry_run ~yes ~opam_repo ~user local_repo
+    remote_repo pkgs auto_open =
   List.fold_left
     (fun acc pkg ->
       get_pkg_dir pkg >>= fun pkg_dir ->
@@ -190,7 +190,7 @@ let submit ~token ~dry_run ~yes ~opam_repo ~user local_repo remote_repo pkgs
   list_map Pkg.name pkgs >>= fun names ->
   let title = strf "[new release] %a (%s)" (pp_list Fmt.string) names version in
   Pkg.publish_msg pkg >>= fun changes ->
-  Pkg.distrib_user_and_repo pkg >>= fun (distrib_user, repo) ->
+  Pkg.distrib_user_and_repo ?uri:distrib_uri pkg >>= fun (distrib_user, repo) ->
   let user =
     match user with
     | Some user -> user (* from the .yaml configuration file *)
@@ -259,8 +259,8 @@ let pkg ?distrib_uri ~dry_run ~pkgs () =
       | (Error _ as e), _ | _, (Error _ as e) -> e)
     (Ok 0) pkgs
 
-let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
-    ~pkg_names ~no_auto_open ~yes () =
+let submit ?distrib_uri ?local_repo ?remote_repo ?opam_repo ?user ?token
+    ~dry_run ~pkgs ~pkg_names ~no_auto_open ~yes () =
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
@@ -284,8 +284,8 @@ let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
   >>= fun token ->
   App_log.status (fun m ->
       m "Submitting %a" Fmt.(list ~sep:sp Text.Pp.name) pkg_names);
-  submit ~token ~dry_run ~yes ~opam_repo ~user:config.user local_repo
-    remote_repo pkgs auto_open
+  submit ?distrib_uri ~token ~dry_run ~yes ~opam_repo ~user:config.user
+    local_repo remote_repo pkgs auto_open
 
 let field ~pkgs ~field_name = field pkgs field_name
 
@@ -299,8 +299,8 @@ let opam_cli () dry_run build_dir local_repo remote_repo opam_repo user keep_v
         | `Descr -> descr ~pkgs
         | `Pkg -> pkg ~dry_run ?distrib_uri ~pkgs ()
         | `Submit ->
-            submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run
-              ~pkgs ~pkg_names ~no_auto_open ~yes ()
+            submit ?distrib_uri ?local_repo ?remote_repo ?opam_repo ?user ?token
+              ~dry_run ~pkgs ~pkg_names ~no_auto_open ~yes ()
         | `Field -> field ~pkgs ~field_name)
   |> Cli.handle_error
 

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -42,6 +42,7 @@ val pkg :
     for success, 1 for failure) or error messages. *)
 
 val submit :
+  ?distrib_uri:string ->
   ?local_repo:string ->
   ?remote_repo:string ->
   ?opam_repo:string * string ->
@@ -54,10 +55,10 @@ val submit :
   yes:bool ->
   unit ->
   (int, Bos_setup.R.msg) result
-(** [submit ?local_repo ?remote_repo ?opam_repo ?user ~dry_run ~pkgs ~pkg_names
-    ~no_auto_open ~yes ()] opens a pull request on the opam repository for the
-    packages [pkgs]. Returns the exit code (0 for success, 1 for failure) or
-    error messages. *)
+(** [submit ?distrib_uri ?local_repo ?remote_repo ?opam_repo ?user ~dry_run
+    ~pkgs ~pkg_names ~no_auto_open ~yes ()] opens a pull request on the opam
+    repository for the packages [pkgs]. Returns the exit code (0 for success, 1
+    for failure) or error messages. *)
 
 val field :
   pkgs:Dune_release.Pkg.t list ->

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -54,17 +54,17 @@ let publish_doc ~specific ~dry_run ~yes pkg_names pkg =
           Ok () )
   | Ok _ -> publish_doc ~dry_run ~yes pkg_names pkg
 
-let publish_distrib ?token ~dry_run ~yes pkg =
+let publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg =
   App_log.status (fun l -> l "Publishing distribution");
   Pkg.distrib_file ~dry_run pkg >>= fun archive ->
   Pkg.publish_msg pkg >>= fun msg ->
-  Delegate.publish_distrib ?token ~dry_run ~yes pkg ~msg ~archive
+  Delegate.publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg ~msg ~archive
 
-let publish_alt ~dry_run pkg kind =
+let publish_alt ?distrib_uri ~dry_run pkg kind =
   App_log.status (fun l -> l "Publishing %s" kind);
   Pkg.distrib_file ~dry_run pkg >>= fun archive ->
   Pkg.publish_msg pkg >>= fun msg ->
-  Delegate.publish_alt ~dry_run pkg ~kind ~msg ~archive
+  Delegate.publish_alt ?distrib_uri ~dry_run pkg ~kind ~msg ~archive
 
 let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
     ?publish_msg ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
@@ -78,14 +78,14 @@ let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
   Config.keep_v keep_v >>= fun keep_v ->
   let pkg =
     Pkg.v ~dry_run ?name ?version ?tag ~keep_v ?build_dir ?opam ?change_log
-      ?distrib_uri ?distrib_file ?publish_msg ?delegate ()
+      ?distrib_file ?publish_msg ?delegate ()
   in
   let publish_artefact acc artefact =
     acc >>= fun () ->
     match artefact with
     | `Doc -> publish_doc ~specific:specific_doc ~dry_run ~yes pkg_names pkg
-    | `Distrib -> publish_distrib ?token ~dry_run ~yes pkg
-    | `Alt kind -> publish_alt ~dry_run pkg kind
+    | `Distrib -> publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg
+    | `Alt kind -> publish_alt ?distrib_uri ~dry_run pkg kind
   in
   List.fold_left publish_artefact (Ok ()) publish_artefacts >>= fun () -> Ok 0
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -94,7 +94,8 @@ let create_config ~user ~remote_repo ~local_repo pkgs file =
   | Some u -> Ok u
   | None ->
       let pkg = List.hd pkgs in
-      Pkg.distrib_user_and_repo pkg >>= fun (u, _) -> Ok u )
+      Pkg.infer_distrib_uri pkg >>= Pkg.distrib_user_and_repo >>= fun (u, _) ->
+      Ok u )
   >>= fun default_user ->
   let user = read_string default_user ~descr:"What is your GitHub ID?" in
   let default_remote =

--- a/lib/delegate.ml
+++ b/lib/delegate.ml
@@ -30,7 +30,10 @@ let publish_distrib ?token ?distrib_uri ~dry_run ~msg ~archive ~yes pkg =
       App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
       Pkg.name pkg >>= fun name ->
       Pkg.tag pkg >>= fun version ->
-      Pkg.distrib_uri ?uri:distrib_uri pkg >>= fun distrib_uri ->
+      ( match distrib_uri with
+      | Some uri -> Ok uri
+      | None -> Pkg.infer_distrib_uri pkg )
+      >>= fun distrib_uri ->
       run_delegate ~dry_run del
         Cmd.(
           v "publish" % "distrib" % distrib_uri % name % version % msg
@@ -56,7 +59,10 @@ let publish_alt ?distrib_uri ~dry_run ~kind ~msg ~archive p =
       App_log.status (fun l -> l "Using delegate %a" Cmd.pp del);
       Pkg.name p >>= fun name ->
       Pkg.version p >>= fun version ->
-      Pkg.distrib_uri ?uri:distrib_uri p >>= fun distrib_uri ->
+      ( match distrib_uri with
+      | Some uri -> Ok uri
+      | None -> Pkg.infer_distrib_uri p )
+      >>= fun distrib_uri ->
       run_delegate ~dry_run del
         Cmd.(
           v "publish" % "alt" % distrib_uri % kind % name % version % msg

--- a/lib/delegate.mli
+++ b/lib/delegate.mli
@@ -14,6 +14,7 @@ open Bos_setup
 
 val publish_distrib :
   ?token:Fpath.t ->
+  ?distrib_uri:string ->
   dry_run:bool ->
   msg:string ->
   archive:Fpath.t ->
@@ -30,6 +31,7 @@ val publish_doc :
   (unit, R.msg) result
 
 val publish_alt :
+  ?distrib_uri:string ->
   dry_run:bool ->
   kind:string ->
   msg:string ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -226,9 +226,9 @@ let assert_tag_exists ~dry_run tag =
   if Vcs.tag_exists ~dry_run repo tag then Ok ()
   else R.error_msgf "%s is not a valid tag" tag
 
-let publish_distrib ?token ~dry_run ~msg ~archive ~yes p =
+let publish_distrib ?token ?distrib_uri ~dry_run ~msg ~archive ~yes p =
   let git_for_repo r = Cmd.of_list (Cmd.to_list @@ Vcs.cmd r) in
-  ( match Pkg.distrib_user_and_repo p with
+  ( match Pkg.distrib_user_and_repo ?uri:distrib_uri p with
   | Error _ as e -> if dry_run then Ok (D.user, D.repo) else e
   | r -> r )
   >>= fun (user, repo) ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -228,7 +228,9 @@ let assert_tag_exists ~dry_run tag =
 
 let publish_distrib ?token ?distrib_uri ~dry_run ~msg ~archive ~yes p =
   let git_for_repo r = Cmd.of_list (Cmd.to_list @@ Vcs.cmd r) in
-  ( match Pkg.distrib_user_and_repo ?uri:distrib_uri p with
+  (match distrib_uri with Some uri -> Ok uri | None -> Pkg.infer_distrib_uri p)
+  >>= fun uri ->
+  ( match Pkg.distrib_user_and_repo uri with
   | Error _ as e -> if dry_run then Ok (D.user, D.repo) else e
   | r -> r )
   >>= fun (user, repo) ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -24,6 +24,7 @@ end
 
 val publish_distrib :
   ?token:Fpath.t ->
+  ?distrib_uri:string ->
   dry_run:bool ->
   msg:string ->
   archive:Fpath.t ->

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -106,7 +106,7 @@ let lint_opam_home_and_dev pkg =
     ~msgf:(fun l ->
       l "opam fields %a and %a can be parsed by dune-release" pp_field
         "homepage" pp_field "dev-repo")
-    (Pkg.distrib_user_and_repo pkg)
+    (Pkg.infer_distrib_uri pkg >>= Pkg.distrib_user_and_repo)
 
 let lint_opam_github_fields pkg = lint_opam_doc pkg + lint_opam_home_and_dev pkg
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -261,16 +261,13 @@ let distrib_uri_of_homepage p =
   | Some (uri, _) ->
       path_of_distrib p >>| fun path -> Some (uri_append uri path)
 
-let distrib_uri ?uri p =
-  ( match uri with
-  | Some u -> Ok u
-  | None -> (
-      distrib_uri_of_homepage p >>= function
-      | Some u -> Ok u
-      | None -> (
-          distrib_uri_of_dev_repo p >>= function
-          | Some u -> Ok u
-          | None -> err_not_found () ) ) )
+let infer_distrib_uri p =
+  (distrib_uri_of_homepage p >>= function
+   | Some u -> Ok u
+   | None -> (
+       distrib_uri_of_dev_repo p >>= function
+       | Some u -> Ok u
+       | None -> err_not_found () ))
   >>= fun uri ->
   ( match uri_domain uri with
   | [ "io"; "github"; user ] -> (
@@ -307,8 +304,7 @@ let distrib_file ~dry_run p =
       |> R.reword_error_msg (fun _ ->
              R.msgf "Did you forget to call 'dune-release distrib' ?")
 
-let distrib_user_and_repo ?uri p =
-  distrib_uri ?uri p >>= fun uri ->
+let distrib_user_and_repo uri =
   let uri_error uri =
     R.msgf
       "Could not derive user and repo from opam dev-repo field value %a; \

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -262,7 +262,7 @@ let distrib_uri_of_homepage p =
   | Some (uri, _) ->
       path_of_distrib p >>| fun path -> Some (uri_append uri path)
 
-let distrib_uri ?(raw = false) p =
+let distrib_uri p =
   let subst_uri p uri =
     name p >>= fun name ->
     tag p >>= fun tag ->
@@ -287,7 +287,7 @@ let distrib_uri ?(raw = false) p =
       | None -> R.error_msgf "invalid uri: %s" uri
       | Some (_, _, path) -> Ok ("https://github.com/" ^ user ^ "/" ^ path) )
   | _ -> Ok uri )
-  >>= fun uri -> if raw then Ok uri else subst_uri p uri
+  >>= subst_uri p
 
 let distrib_filename ?(opam = false) p =
   let sep = if opam then '.' else '-' in

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -80,8 +80,9 @@ val change_log : t -> (Fpath.t, R.msg) result
 val licenses : t -> (Fpath.t list, R.msg) result
 (** [licenses p] are [p]'s license files. *)
 
-val distrib_uri : ?uri:string -> t -> (string, R.msg) result
-(** [distrib_uri p] is [p]'s distribution URI. *)
+val infer_distrib_uri : t -> (string, R.msg) result
+(** [infer_distrib_uri p] infers [p]'s distribution URI from the homepage and
+    dev-repo fields. *)
 
 val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_file p] is [p]'s distribution archive. *)
@@ -115,7 +116,7 @@ val doc_dir : Fpath.t
 
 val doc_user_repo_and_path : t -> (string * string * Fpath.t, R.msg) result
 
-val distrib_user_and_repo : ?uri:string -> t -> (string * string, R.msg) result
+val distrib_user_and_repo : string -> (string * string, R.msg) result
 
 type f =
   dry_run:bool ->

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -81,9 +81,8 @@ val change_log : t -> (Fpath.t, R.msg) result
 val licenses : t -> (Fpath.t list, R.msg) result
 (** [licenses p] are [p]'s license files. *)
 
-val distrib_uri : ?raw:bool -> t -> (string, R.msg) result
-(** [distrib_uri p] is [p]'s distribution URI. If [raw] is [true] defaults to
-    [false], [p]'s raw URI distribution pattern is returned. *)
+val distrib_uri : t -> (string, R.msg) result
+(** [distrib_uri p] is [p]'s distribution URI. *)
 
 val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_file p] is [p]'s distribution archive. *)

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -26,7 +26,6 @@ val v :
   ?readme:Fpath.t ->
   ?change_log:Fpath.t ->
   ?license:Fpath.t ->
-  ?distrib_uri:string ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
   ?distrib:Distrib.t ->
@@ -81,7 +80,7 @@ val change_log : t -> (Fpath.t, R.msg) result
 val licenses : t -> (Fpath.t list, R.msg) result
 (** [licenses p] are [p]'s license files. *)
 
-val distrib_uri : t -> (string, R.msg) result
+val distrib_uri : ?uri:string -> t -> (string, R.msg) result
 (** [distrib_uri p] is [p]'s distribution URI. *)
 
 val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
@@ -116,7 +115,7 @@ val doc_dir : Fpath.t
 
 val doc_user_repo_and_path : t -> (string * string * Fpath.t, R.msg) result
 
-val distrib_user_and_repo : t -> (string * string, R.msg) result
+val distrib_user_and_repo : ?uri:string -> t -> (string * string, R.msg) result
 
 type f =
   dry_run:bool ->

--- a/tests/lib/test_tags.ml
+++ b/tests/lib/test_tags.ml
@@ -57,7 +57,9 @@ let distrib_filename =
 
 let distrib_uri =
   let cat = "distrib_uri" in
-  let check = check ~cat ~name:"yo" (fun x -> Pkg.distrib_uri x >>| Fpath.v) in
+  let check =
+    check ~cat ~name:"yo" (fun x -> Pkg.infer_distrib_uri x >>| Fpath.v)
+  in
   let dev_repo = [ ("dev-repo", "git@github.com:foo/bar.git") ] in
   let homepage = [ ("homepage", "https://github.com/foo/bar") ] in
   let url = "https://github.com/foo/bar/releases/download/v0/yo-v0.tbz" in


### PR DESCRIPTION
Should not change the behavior of dune-release:
- remove `distrib_uri` field from `Pkg.t` type
- remove `?distrib_uri` arg from `Pkg.v` function
- remove `?raw` arg from `Pkg.distrib_uri` function
- ~add `?uri` arg to `Pkg.distrib_uri` function~
- ~add `?uri` arg to `Pkg.distrib_user_and_repo` function~
- pass `?distrib_uri` arg to functions calling one of these two functions
- ~split `Pkg.distrib_uri` into `Pkg.infer_distrib_uri` and `Pkg.normalize_distrib_uri`~
- rename `Pkg.distrib_uri` to `Pkg.infer_distrib_uri`