### PR TITLE
Build and run tests for all selected packages in distrib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 - Use int64 for timestamps. (#261, @gpetiot)
 - Define the order of packages (#263, @gpetiot)
 - Allow the dry-run mode to continue even after some API call's response were expected by using placeholder values (#262, @gpetiot)
+- Build and run tests for all selected packages when checking distribution tarball
+  (#266, @NathanReb)
 
 ### Security
 

--- a/bin/distrib.ml
+++ b/bin/distrib.ml
@@ -48,8 +48,10 @@ let check_archive ~dry_run ~skip_lint ~skip_build ~skip_tests ~pkg_names pkg ar
   Pkg.infer_pkg_names dir pkg_names >>= fun pkg_names ->
   (if skip_lint then Ok 0 else lint_distrib ~dry_run ~dir ~pkg_names pkg)
   >>= fun c0 ->
-  (if skip_build then Ok 0 else build_distrib ~dry_run ~dir pkg) >>= fun c1 ->
-  (if skip_tests || skip_build then Ok 0 else test_distrib ~dry_run ~dir pkg)
+  (if skip_build then Ok 0 else build_distrib ~dry_run ~dir pkg_names)
+  >>= fun c1 ->
+  ( if skip_tests || skip_build then Ok 0
+  else test_distrib ~dry_run ~dir pkg_names )
   >>= fun c2 ->
   match c0 + c1 + c2 with
   | 0 -> Sos.delete_dir ~dry_run dir >>= fun () -> Ok 0

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -560,20 +560,20 @@ type f =
   dir:Fpath.t ->
   args:Cmd.t ->
   out:(OS.Cmd.run_out -> (string * OS.Cmd.run_status, Sos.error) result) ->
-  t ->
+  string list ->
   (string * OS.Cmd.run_status, Sos.error) result
 
-let run ~dry_run ~dir ~args ~out ~default p cmd =
-  let name = p.name in
-  let cmd = Cmd.(v "dune" % cmd % "-p" % name %% args) in
+let run ~dry_run ~dir ~args ~out ~default pkg_names cmd =
+  let pkgs = String.concat ~sep:"," pkg_names in
+  let cmd = Cmd.(v "dune" % cmd % "-p" % pkgs %% args) in
   let run () = Sos.run_out ~dry_run cmd ~default out in
   R.join @@ Sos.with_dir ~dry_run dir run ()
 
-let test ~dry_run ~dir ~args ~out p =
-  run ~dry_run ~dir ~args ~out ~default:(Sos.out "") p "runtest"
+let test ~dry_run ~dir ~args ~out pkg_names =
+  run ~dry_run ~dir ~args ~out ~default:(Sos.out "") pkg_names "runtest"
 
-let build ~dry_run ~dir ~args ~out p =
-  run ~dry_run ~dir ~args ~out ~default:(Sos.out "") p "build"
+let build ~dry_run ~dir ~args ~out pkg_names =
+  run ~dry_run ~dir ~args ~out ~default:(Sos.out "") pkg_names "build"
 
 (* tags *)
 

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -124,7 +124,7 @@ type f =
   dir:Fpath.t ->
   args:Cmd.t ->
   out:(OS.Cmd.run_out -> (string * OS.Cmd.run_status, Sos.error) result) ->
-  t ->
+  string list ->
   (string * OS.Cmd.run_status, Sos.error) result
 
 (** {1 Test} *)

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -96,12 +96,12 @@ We make a dry-run release
     
     [-] Building package in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
-    -: exec: dune build -p whatever
+    -: exec: dune build -p whatever,whatever-lib
     [ OK ] package builds
     
     [-] Running package tests in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
-    -: exec: dune runtest -p whatever
+    -: exec: dune runtest -p whatever,whatever-lib
     [ OK ] package tests
     -: rmdir _build/whatever-0.1.0
     
@@ -177,12 +177,12 @@ We do the whole process, calling publish doc implicitely should succeed
     
     [-] Building package in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
-    -: exec: dune build -p whatever
+    -: exec: dune build -p whatever,whatever-lib
     [ OK ] package builds
     
     [-] Running package tests in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
-    -: exec: dune runtest -p whatever
+    -: exec: dune runtest -p whatever,whatever-lib
     [ OK ] package tests
     -: rmdir _build/whatever-0.1.0
     


### PR DESCRIPTION
Fixes #244

They used to only run for the main package in multi-opam repos.