### PR TITLE
Infer the main package from the dune-project if possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@
   dune-project would be silently ignored by `dune-release distrib`.
 - Fix rewriting of github references in changelog (#330, @gpetiot)
 - Fixes a bug under cygwin where dune-release was unable to find the commit hash corresponding to the release tag (#329, @gpetiot)
+- Infer the main package from the dune-project if possible (#267, @gpetiot)
 
 ### Security
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -84,7 +84,7 @@ let read_string default ~descr =
     default;
   match read () with None -> default | Some s -> s
 
-let create_config ~user ~remote_repo ~local_repo pkgs file =
+let create_config ~user ~remote_repo ~local_repo pkg file =
   Fmt.pr
     "%a does not exist!\n\
      Please answer a few questions to help me create it for you:\n\n\
@@ -93,7 +93,6 @@ let create_config ~user ~remote_repo ~local_repo pkgs file =
   (match user with
   | Some u -> Ok u
   | None ->
-      let pkg = List.hd pkgs in
       Pkg.infer_distrib_uri pkg >>= Pkg.distrib_user_and_repo >>= fun (u, _) ->
       Ok u)
   >>= fun default_user ->
@@ -155,10 +154,10 @@ let find () =
   OS.File.exists file >>= fun exists ->
   if exists then OS.File.read file >>= of_yaml >>| fun x -> Some x else Ok None
 
-let v ~user ~remote_repo ~local_repo pkgs =
+let v ~user ~remote_repo ~local_repo pkg =
   find () >>= function
   | Some f -> Ok f
-  | None -> file () >>= create_config ~user ~remote_repo ~local_repo pkgs
+  | None -> file () >>= create_config ~user ~remote_repo ~local_repo pkg
 
 let reset_terminal : (unit -> unit) option ref = ref None
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -26,7 +26,7 @@ val v :
   user:string option ->
   remote_repo:string option ->
   local_repo:string option ->
-  Pkg.t list ->
+  Pkg.t ->
   (t, Bos_setup.R.msg) result
 
 val token : dry_run:bool -> unit -> (Fpath.t, Bos_setup.R.msg) result

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -48,10 +48,8 @@ let cmd = Cmd.of_list @@ Cmd.to_list @@ tool "opam" `Host_os
 
 (* Publish *)
 
-let shortest x =
-  List.hd (List.sort (fun x y -> compare (String.length x) (String.length y)) x)
-
-let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
+let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version ~main_pkg
+    ~all_pkgs =
   let msg =
     match msg with
     | None -> Ok Cmd.empty
@@ -74,8 +72,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
     Printf.sprintf "https://github.com/%s/%s.git" user repo
   in
   let remote_branch = "master" in
-  let pkg = shortest names in
-  let branch = Fmt.strf "release-%s-%s" pkg version in
+  let branch = Fmt.strf "release-%s-%s" main_pkg version in
   let prepare_repo () =
     App_log.status (fun l ->
         l "Fetching %a" Text.Pp.url (upstream ^ "#" ^ remote_branch));
@@ -148,7 +145,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version names =
   Sos.with_dir ~dry_run local_repo
     (fun () ->
       prepare_repo () >>= fun () ->
-      prepare_packages names >>= fun () ->
+      prepare_packages all_pkgs >>= fun () ->
       commit_and_push () >>= fun () -> Ok branch)
     ()
   |> R.join

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -22,11 +22,13 @@ val prepare :
   remote_repo:string ->
   opam_repo:string * string ->
   version:string ->
-  string list ->
+  main_pkg:string ->
+  all_pkgs:string list ->
   (string, R.msg) result
-(** [prepare ~local_repo ~version pkgs] adds the packages [pkg.version] to a new
-    branch in the local opam repository [local_repo], using the commit message
-    [msg] (if any). Return the new branch. *)
+(** [prepare ~local_repo ~version ~main_pkg ~all_pkgs] adds the packages from
+    [all_pkgs] to a new branch named "release-[main_pkg]-version" in the local
+    opam repository [local_repo], using the commit message [msg] (if any).
+    Commits and pushes the changes, then returns the new branch. *)
 
 (** {1:file Files} *)
 

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -438,6 +438,10 @@ let infer_name dir =
                      (name <name>) to dune-project");
               exit 1))
 
+let infer_main_pkg dir pkgs =
+  infer_name dir >>| fun main_pkg_name ->
+  List.find (fun pkg -> String.equal pkg.name main_pkg_name) pkgs
+
 let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir
     ?opam:opam_file ?opam_descr ?readme ?change_log ?license ?distrib_file
     ?publish_msg () =

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -34,6 +34,9 @@ val v :
 val infer_pkg_names : Fpath.t -> string list -> (string list, R.msg) result
 (** Infer the package list. *)
 
+val infer_main_pkg : Fpath.t -> t list -> (t, R.msg) result
+(** Infer the main package. *)
+
 val name : t -> (string, R.msg) result
 (** [name p] is [p]'s name. *)
 


### PR DESCRIPTION
fix #265
~This PR defines a new package `Mlist` in `Stdext`, for "main" list (didn't find a better name) to distinguish the main element of the list from others elements of the list, and we maintain this distinction for packages everywhere it makes sense. So the main package can be retrieved directly, without assuming it is the first element of the list or that it has the shortest name of all elements.~

edit: I improved the PR to define `Pkg.infer_main_pkg` instead (in the same way the new `Pkg.infer_pkg_names` was defined), so the main package can be passed along the package list, parameters have also been named to avoid being confused by generic pkg/pkgs variables. Let me know what you think.