### PR TITLE
Add support for lightweight tags

### DIFF
--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -96,7 +96,7 @@ let git_describe ~dirty r commit_ish =
   let dirty = dirty && commit_ish = "HEAD" in
   let git_describe =
     Cmd.(
-      git_work_tree r % "describe" % "--always"
+      git_work_tree r % "describe" % "--always" % "--tags"
       %% on dirty (v "--dirty")
       %% on (not dirty) (v commit_ish))
   in


### PR DESCRIPTION
Currently dune-release does not support lightweight tags (aka. default tags), so for instance if a user already pushed a tag in the following manner:
```
$ git tag v0.1
$ git push origin master
$ git push origin v0.1
```
dune-release will not realize that the tag already exists and will want to create a nonsensical tag instead (e.g. `v0.1-16-g21abe5d`).

Currently https://github.com/ocamllabs/dune-release/pull/219 is needed to be able to use `dune-release` directly afterward, but it's still makes sense to allow lightweight tags.