### PR TITLE
Deprecate delegates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Attach the changelog to the annotated tag message (#283, @gpetiot)
+- Deprecate the use of delegates in `dune-release publish` (#276, @pitag-ha)
 
 ### Deprecated
 

--- a/bin/help.ml
+++ b/bin/help.ml
@@ -168,6 +168,7 @@ let release =
 let delegate =
   ( ("DUNE-RELEASE-DELEGATE", 7, "", version, dune_release_manual),
     [
+      `I ("$(b,Warning)", Dune_release.Deprecate_delegates.warning);
       `S Manpage.s_name;
       `P "dune-release-delegate - The dune-release publish delegate";
       `S Manpage.s_description;

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -42,7 +42,9 @@ let publish_doc ~specific ~dry_run ~yes pkg_names pkg =
   | _ when specific -> publish_doc ~dry_run ~yes pkg_names pkg
   | Error _ | Ok "" -> (
       match Pkg.delegate pkg with
-      | Ok (Some _) -> publish_doc ~dry_run ~yes pkg_names pkg
+      | Ok (Some _) ->
+          App_log.unhappy (fun l -> l Deprecate_delegates.warning_usage);
+          publish_doc ~dry_run ~yes pkg_names pkg
       | Error _ | Ok None ->
           Pkg.name pkg >>= fun name ->
           Pkg.opam pkg >>= fun opam ->
@@ -59,12 +61,6 @@ let publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg =
   Pkg.distrib_file ~dry_run pkg >>= fun archive ->
   Pkg.publish_msg pkg >>= fun msg ->
   Delegate.publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg ~msg ~archive
-
-let publish_alt ?distrib_uri ~dry_run pkg kind =
-  App_log.status (fun l -> l "Publishing %s" kind);
-  Pkg.distrib_file ~dry_run pkg >>= fun archive ->
-  Pkg.publish_msg pkg >>= fun msg ->
-  Delegate.publish_alt ?distrib_uri ~dry_run pkg ~kind ~msg ~archive
 
 let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
     ?publish_msg ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
@@ -85,7 +81,7 @@ let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
     match artefact with
     | `Doc -> publish_doc ~specific:specific_doc ~dry_run ~yes pkg_names pkg
     | `Distrib -> publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg
-    | `Alt kind -> publish_alt ?distrib_uri ~dry_run pkg kind
+    | `Alt kind -> Deprecate_delegates.publish_alt ~dry_run pkg kind
   in
   List.fold_left publish_artefact (Ok ()) publish_artefacts >>= fun () -> Ok 0
 
@@ -103,8 +99,10 @@ open Cmdliner
 
 let delegate =
   let doc =
-    "The delegate tool $(docv) to use. If absent, see dune-release-delegate(7) \
-     for the lookup procedure."
+    "Warning: " ^ Deprecate_delegates.warning
+    ^ "\n\
+      \ The delegate tool $(docv) to use. If absent, see \
+       dune-release-delegate(7) for the lookup procedure."
   in
   let docv = "TOOL" in
   let to_cmd = function None -> None | Some s -> Some (Cmd.v s) in
@@ -120,13 +118,15 @@ let artefacts =
     | s when String.is_prefix ~affix:alt_prefix s -> (
         match String.(with_range ~first:(length alt_prefix) s) with
         | "" -> `Error "`alt-' alternative artefact kind is missing"
-        | kind -> `Ok (`Alt kind) )
+        | kind ->
+            App_log.unhappy (fun l -> l Deprecate_delegates.warning_usage);
+            `Ok (`Alt kind) )
     | s -> `Error (strf "`%s' unknown publication artefact" s)
   in
   let printer ppf = function
     | `Doc -> Fmt.string ppf "doc"
     | `Distrib -> Fmt.string ppf "distrib"
-    | `Alt a -> Fmt.pf ppf "alt-%s" a
+    | `Alt a -> Fmt.pf ppf Deprecate_delegates.alt_artefacts_pp a
   in
   let artefact = (parser, printer) in
   let doc =
@@ -137,17 +137,16 @@ let artefacts =
   in
   Arg.(value & pos_all artefact [] & info [] ~doc ~docv:"ARTEFACT")
 
-let doc = "Publish package distribution archives and derived artefacts"
+let doc =
+  Deprecate_delegates.artefacts_warning
+  ^ "Publish package distribution archives and other artefacts"
 
 let sdocs = Manpage.s_common_options
 
 let exits = Cli.exits
 
 let envs =
-  [
-    Term.env_info "DUNE_RELEASE_DELEGATE"
-      ~doc:"The package delegate to use, see dune-release-delegate(7).";
-  ]
+  [ Term.env_info "DUNE_RELEASE_DELEGATE" ~doc:Deprecate_delegates.env_var_doc ]
 
 let man_xrefs = [ `Main; `Cmd "distrib" ]
 
@@ -157,8 +156,9 @@ let man =
     `P "$(mname) $(tname) [$(i,OPTION)]... [$(i,ARTEFACT)]...";
     `S Manpage.s_description;
     `P
-      "The $(tname) command publishes package distribution archives and other \
-       artefacts.";
+      ( Deprecate_delegates.artefacts_warning
+      ^ "The $(tname) command publishes package distribution archives and \
+         other artefacts." );
     `P
       "Artefact publication always relies on a distribution archive having \
        been generated before with dune-release-distrib(1).";
@@ -167,12 +167,7 @@ let man =
     `I
       ( "$(b,doc)",
         "Publishes the documentation of a distribution archive on the WWW." );
-    `I
-      ( "$(b,alt)-$(i,KIND)",
-        "Publishes the alternative artefact of kind $(i,KIND) of a \
-         distribution archive. The semantics of alternative artefacts is left \
-         to the delegate, it could be anything, an email, a pointless tweet, a \
-         feed entry etc. See dune-release-delegate(7) for more details." );
+    `I ("$(b,alt)-$(i,KIND)", Deprecate_delegates.module_publish_man_alt);
   ]
 
 let cmd =

--- a/lib/deprecate_delegates.ml
+++ b/lib/deprecate_delegates.ml
@@ -1,0 +1,37 @@
+let warning =
+  "dune-release delegates are deprecated. They will be removed in version \
+   2.0.0."
+
+let warning_usage : ('a, Format.formatter, unit, unit) format4 =
+  "Warning: You are using delegates. The use of delegates is deprecated. It \
+   will be removed in version 2.0.0."
+
+let env_var_doc =
+  "Warning: this environment variable is deprecated. It will be removed in \
+   version 2.0.0. \n\
+   The package delegate to use, see dune-release-delegate(7)."
+
+let artefacts_warning =
+  "Warning: publishing other artefacts is deprecated. It will be disabled in \
+   version 2.0.0.\n"
+
+let module_publish_man_alt =
+  "Warning: this artefact is deprecated. It will be removed in version 2.0.0. \n\
+  \ Publishes the alternative artefact of kind $(i,KIND) of a distribution \
+   archive. The semantics of alternative artefacts is left to the delegate, it \
+   could be anything, an email, a pointless tweet, a feed entry etc. See \
+   dune-release-delegate(7) for more details."
+
+let alt_artefacts_pp : ('a -> 'b, Format.formatter, unit) format =
+  "alt-%s(deprecated)"
+
+let publish_alt ?distrib_uri ~dry_run pkg kind =
+  let open Bos_setup in
+  App_log.unhappy (fun l ->
+      l
+        "Warning: the use of alternative artefacts is deprecated. It will be \
+         removed in version 2.0.0.");
+  App_log.status (fun l -> l "Publishing %s" kind);
+  Pkg.distrib_file ~dry_run pkg >>= fun archive ->
+  Pkg.publish_msg pkg >>= fun msg ->
+  Delegate.publish_alt ?distrib_uri ~dry_run pkg ~kind ~msg ~archive


### PR DESCRIPTION
This commit deprecates the use of delegates and publishing artefacts other than the distribution archive or the documentation, since those functionalities will be removed in the next major release. Deprecating delegates is point 3. of #188.

In order to remove delegates, we'll have to 
- remove the modules `Deprecate_delegates` and `Delegate`
- follow the provoked compile errors
- get rid of the delegate structure in `Pkg` 
- think about where to check if the user is using something else than github (provided in the opam `doc:` or `homepage:` field) to let them know early that dune-release doesn't support that. Maybe through the linter?