### PR TITLE
Create github releases only if necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Don't try to push the tag if it is already present and point to the same ref on the remote.
   `dune-release` must guess which URI to pass to `git push` and may guess it wrong.
   This change allows users to push the tag manually to avoid using that code. (#219, @Julow)
+- Don't try to create the release if it is already present and points to the same tag (#277, @kit-ty-kate)
 - Recursively exclude all `.git`/`.hg` files and folders from the distrib
   tarball (#300, @NathanReb)
 - Make the automatic dune-release workflow to stop if a step exits with a non-zero code (#332, @gpetiot)

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -26,6 +26,16 @@ let create_release ~version ~tag ~msg ~user ~repo =
   in
   { url; args }
 
+let get_release ~version ~user ~repo =
+  let url =
+    strf "https://api.github.com/repos/%s/%s/releases/tags/%s" user repo version
+  in
+  let args =
+    let open Curl_option in
+    [ Location; Silent; Show_error; Config `Stdin; Dump_header `Ignore ]
+  in
+  { url; args }
+
 let upload_archive ~archive ~user ~repo ~release_id =
   let url =
     strf "https://uploads.github.com/repos/%s/%s/releases/%d/assets?name=%s"

--- a/lib/curl.mli
+++ b/lib/curl.mli
@@ -3,6 +3,8 @@ type t = { url : string; args : Curl_option.t list }
 val create_release :
   version:string -> tag:string -> msg:string -> user:string -> repo:string -> t
 
+val get_release : version:string -> user:string -> repo:string -> t
+
 val upload_archive :
   archive:Fpath.t -> user:string -> repo:string -> release_id:int -> t
 


### PR DESCRIPTION
This PR is built on top of https://github.com/ocamllabs/dune-release/pull/219 by @julow which allows for git tags to not be created if they already exist. This PR takes a notch further and does not create a github release if it already exists.

This might be useful for people who want custom github releases messages or something and still want to use dune-release for the rest. It might also be useful for people who, like myself, are too used to `opam-publish` and already created a tag and release before calling `dune-release`.
People might also be in the same situation if something did not work when they used `opam-publish`, then tries to use `dune-release` instead but the workflow is too different for them and they give up (either give up using opam altogether or release by hand).

I hope this can help people transition from opam-publish if they want to or simply allow people to have finer control over what they are doing.