### PR TITLE
Log curl calls on debug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Add a `--token` option to `dune-release publish` and `dune-release opam` commands to specify a github token. This allows dune-release to be called through a Github Actions workflow and use the github token through an environment variable. (#284, @gpetiot)
+- Log curl calls on verbose/debug mode (#281, @gpetiot)
 
 ### Changed
 


### PR DESCRIPTION
Fix #280

No diff in the tests since we only use dry-mode to not submit pull requests and so on.