### PR TITLE
Linter: check for synopsis instead of description 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 - Make the automatic dune-release workflow to stop if a step exits with a non-zero code (#332, @gpetiot)
 - Make git-related mdx tests more robust in unusual environments (#334, @sternenseemann)
 - Set the default tag message to "Release <tag>" instead of "Distribution <tag>"
+- Opam file linter: check for `synopsis` instead of `description` (#291, @kit-ty-kate)
 
 ### Deprecated
 

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -130,16 +130,16 @@ let handle_opam_lint_exit ~dry_run ~verbose_lint_cmd ~opam_file status output =
       match verbose_lint_output with
       | Ok (out, _) | Error (`Msg out) -> `Fail out)
 
-let check_has_description ~opam_file pkg =
-  Pkg.opam_field_hd pkg "description" >>= function
+let check_has_synopsis ~opam_file pkg =
+  Pkg.opam_field_hd pkg "synopsis" >>= function
   | None ->
-      R.error_msgf "%a does not have a 'description' field." Fpath.pp opam_file
+      R.error_msgf "%a does not have a 'synopsis' field." Fpath.pp opam_file
   | Some _ -> Ok ()
 
 let lint_descr ~opam_file pkg =
   lint_res
-    ~msgf:(fun l -> l "opam field %a is present" pp_field "description")
-    (check_has_description ~opam_file pkg)
+    ~msgf:(fun l -> l "opam field %a is present" pp_field "synopsis")
+    (check_has_synopsis ~opam_file pkg)
 
 let opam_lint ~dry_run ~opam_file_version ~opam_tool_version opam_file =
   let base_lint_cmd = opam_lint_cmd ~opam_file_version ~opam_tool_version in

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -44,7 +44,7 @@ If the condition described above is fulfilled, there are 4 checks to be performe
     [FAIL] File CHANGES is missing.
     [ OK ] File opam is present.
     [ OK ] lint opam file my_pkg.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
     [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
@@ -81,7 +81,7 @@ In multi package projects, the whole lint process (including the file lints, eve
     [FAIL] File CHANGES is missing.
     [ OK ] File opam is present.
     [ OK ] lint opam file my_pkg.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
     [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
@@ -92,7 +92,7 @@ In multi package projects, the whole lint process (including the file lints, eve
     [FAIL] File CHANGES is missing.
     [ OK ] File opam is present.
     [ OK ] lint opam file my_pkg-sub.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
     [FAIL] lint of <project_dir> and package my_pkg-sub failure: 3 errors.

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -14,13 +14,13 @@ We need a basic opam project skeleton with an empty doc field
     > opam-version: "2.0"\
     > homepage: "https://github.com/foo/whatever"\
     > dev-repo: "git+https://github.com/foo/whatever.git"\
-    > description: "whatever"\
+    > synopsis: "whatever"\
     > EOF
     $ cat > whatever-lib.opam << EOF \
     > opam-version: "2.0"\
     > homepage: "https://github.com/foo/whatever"\
     > dev-repo: "git+https://github.com/foo/whatever.git"\
-    > description: "whatever-lib"\
+    > synopsis: "whatever-lib"\
     > doc: ""\
     > EOF
     $ touch README

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -14,7 +14,7 @@ We need a basic opam project skeleton
     > homepage: "https://whatever.io"\
     > dev-repo: "git+https://whatever.io/dev/whatever.git"\
     > doc: "https://whatever.io/doc/main.html"\
-    > description: "whatever"\
+    > synopsis: "whatever"\
     > EOF
     $ touch README
     $ touch LICENSE
@@ -77,7 +77,7 @@ We do the whole dune-release process
     [ OK ] File opam is present.
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
     dune-release: [ERROR] Github development repository URL could not be
                           inferred.

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -13,7 +13,7 @@ We need a basic opam project skeleton
     > opam-version: "2.0"\
     > homepage: "https://whatever.io"\
     > dev-repo: "git+https://whatever.io/dev/whatever.git"\
-    > description: "whatever"\
+    > synopsis: "whatever"\
     > EOF
     $ touch README
     $ touch LICENSE
@@ -77,7 +77,7 @@ We do the whole dune-release process
     [ OK ] File opam is present.
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
     dune-release: [ERROR] Github development repository URL could not be
                           inferred.

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -13,7 +13,7 @@ We need a basic opam project skeleton
     > opam-version: "2.0"\
     > homepage: "https://github.com/foo/whatever"\
     > dev-repo: "git+https://github.com/foo/whatever.git"\
-    > description: "whatever"\
+    > synopsis: "whatever"\
     > EOF
     $ touch README
     $ touch LICENSE
@@ -77,7 +77,7 @@ We make a dry-run release:
     [ OK ] File opam is present.
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] Skipping doc field linting, no doc field found
     [ OK ] lint of _build/whatever-0.1.0 and package whatever success
@@ -134,9 +134,8 @@ We make a dry-run release:
     opam-version: "2.0"
     homepage: "https://github.com/foo/whatever"
     dev-repo: "git+https://github.com/foo/whatever.git"
-    description: "whatever"
+    synopsis: "whatever"
     x-commit-hash: ...
-    synopsis: ""
     url {
       src: "https://foo.fr/archive/foo/foo.tbz"
       checksum: [

--- a/tests/bin/x-commit-hash/run.t
+++ b/tests/bin/x-commit-hash/run.t
@@ -14,7 +14,7 @@ We need a basic opam project skeleton
     > homepage: "https://github.com/foo/whatever"\
     > dev-repo: "git+https://github.com/foo/whatever.git"\
     > doc: "https://foo.github.io/whatever/"\
-    > description: "whatever"\
+    > synopsis: "whatever"\
     > EOF
     $ touch README
     $ touch LICENSE
@@ -76,7 +76,7 @@ We make a dry-run release
     [ OK ] File opam is present.
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field description is present
+    [ OK ] opam field synopsis is present
     [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
     [ OK ] opam field doc can be parsed by dune-release
     [ OK ] lint of _build/whatever-0.1.0 and package whatever success


### PR DESCRIPTION
Many packages are simple enough and just have a `synopsis` field, the `description` field is not required if `synopsis` is present.
Furthermore, only `synopsis` is shown during `opam search` or `opam list`.