### PR TITLE
Wrap cmdliner arguments with variants to prevent args order mistakes

### DIFF
--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -6,7 +6,8 @@
 
 open Bos_setup.R.Infix
 
-let bistro () dry_run name pkg_names version tag keep_v token =
+let bistro () (`Dry_run dry_run) (`Dist_name name) (`Package_names pkg_names)
+    (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v) (`Token token) =
   Cli.handle_error
     ( Dune_release.Config.keep_v keep_v >>= fun keep_v ->
       Distrib.distrib ~dry_run ~name ~pkg_names ~version ~tag ~keep_v

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -14,10 +14,14 @@ open Dune_release
 
 let path_arg = Arg.conv Fpath.(of_string, pp)
 
+let named f = Cmdliner.Term.(app (const f))
+
 let dist_tag =
   let doc = "The tag from which the distribution archive is built." in
-  Arg.(
-    value & opt (some string) None & info [ "t"; "tag" ] ~doc ~docv:"DIST_TAG")
+  named
+    (fun x -> `Dist_tag x)
+    Arg.(
+      value & opt (some string) None & info [ "t"; "tag" ] ~doc ~docv:"DIST_TAG")
 
 let dist_name =
   let doc =
@@ -27,7 +31,9 @@ let dist_name =
      word in the title of $(b,README.md)."
   in
   let docv = "DIST_NAME" in
-  Arg.(value & opt (some string) None & info [ "n"; "name" ] ~doc ~docv)
+  named
+    (fun x -> `Dist_name x)
+    Arg.(value & opt (some string) None & info [ "n"; "name" ] ~doc ~docv)
 
 let pkg_names =
   let doc =
@@ -35,7 +41,9 @@ let pkg_names =
      the $(b,*.opam) files present in the current directory."
   in
   let docv = "PKG_NAMES" in
-  Arg.(value & opt (list string) [] & info [ "p"; "pkg-names" ] ~doc ~docv)
+  named
+    (fun x -> `Package_names x)
+    Arg.(value & opt (list string) [] & info [ "p"; "pkg-names" ] ~doc ~docv)
 
 let pkg_version =
   let doc =
@@ -43,7 +51,10 @@ let pkg_version =
      tag."
   in
   let docv = "PKG_VERSION" in
-  Arg.(value & opt (some string) None & info [ "-V"; "pkg-version" ] ~doc ~docv)
+  named
+    (fun x -> `Package_version x)
+    Arg.(
+      value & opt (some string) None & info [ "-V"; "pkg-version" ] ~doc ~docv)
 
 let opam =
   let doc =
@@ -51,7 +62,9 @@ let opam =
      the package description."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some path_arg) None & info [ "opam" ] ~doc ~docv)
+  named
+    (fun x -> `Opam x)
+    Arg.(value & opt (some path_arg) None & info [ "opam" ] ~doc ~docv)
 
 let token =
   let doc =
@@ -63,11 +76,13 @@ let token =
   in
   let docv = "FILE" in
   let env = Arg.env_var "DUNE_RELEASE_GITHUB_TOKEN" in
-  Arg.(value & opt (some path_arg) None & info [ "token" ] ~doc ~docv ~env)
+  named
+    (fun x -> `Token x)
+    Arg.(value & opt (some path_arg) None & info [ "token" ] ~doc ~docv ~env)
 
 let keep_v =
   let doc = "Do not drop the initial 'v' in the version string." in
-  Arg.(value & flag & info [ "keep-v" ] ~doc)
+  named (fun x -> `Keep_v x) Arg.(value & flag & info [ "keep-v" ] ~doc)
 
 let dist_file =
   let doc =
@@ -76,7 +91,9 @@ let dist_file =
      $(b,--dist-name) and $(b,--dist-version))."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some path_arg) None & info [ "dist-file" ] ~doc ~docv)
+  named
+    (fun x -> `Dist_file x)
+    Arg.(value & opt (some path_arg) None & info [ "dist-file" ] ~doc ~docv)
 
 let dist_opam =
   let doc =
@@ -85,7 +102,9 @@ let dist_opam =
      package name $(i,NAME) (see option $(b,--dist-name))."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some path_arg) None & info [ "dist-opam" ] ~doc ~docv)
+  named
+    (fun x -> `Dist_opam x)
+    Arg.(value & opt (some path_arg) None & info [ "dist-opam" ] ~doc ~docv)
 
 let dist_uri =
   let doc =
@@ -93,21 +112,27 @@ let dist_uri =
      package description."
   in
   let docv = "URI" in
-  Arg.(value & opt (some string) None & info [ "dist-uri" ] ~doc ~docv)
+  named
+    (fun x -> `Dist_uri x)
+    Arg.(value & opt (some string) None & info [ "dist-uri" ] ~doc ~docv)
 
 let readme =
   let doc =
     "The readme to use. If absent, provided by the package description."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some path_arg) None & info [ "readme" ] ~doc ~docv)
+  named
+    (fun x -> `Readme x)
+    Arg.(value & opt (some path_arg) None & info [ "readme" ] ~doc ~docv)
 
 let change_log =
   let doc =
     "The change log to use. If absent, provided by the package description."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some path_arg) None & info [ "change-log" ] ~doc ~docv)
+  named
+    (fun x -> `Change_log x)
+    Arg.(value & opt (some path_arg) None & info [ "change-log" ] ~doc ~docv)
 
 let build_dir =
   let doc =
@@ -115,7 +140,9 @@ let build_dir =
      description."
   in
   let docv = "BUILD_DIR" in
-  Arg.(value & opt (some path_arg) None & info [ "build-dir" ] ~doc ~docv)
+  named
+    (fun x -> `Build_dir x)
+    Arg.(value & opt (some path_arg) None & info [ "build-dir" ] ~doc ~docv)
 
 let publish_msg =
   let doc =
@@ -123,17 +150,19 @@ let publish_msg =
      version (see $(b,dune-release log -l))."
   in
   let docv = "MSG" in
-  Arg.(value & opt (some string) None & info [ "m"; "message" ] ~doc ~docv)
+  named
+    (fun x -> `Publish_msg x)
+    Arg.(value & opt (some string) None & info [ "m"; "message" ] ~doc ~docv)
 
 let dry_run =
   let doc =
     "Don't actually perform any action, just show what would be done."
   in
-  Arg.(value & flag & info [ "dry-run" ] ~doc)
+  named (fun x -> `Dry_run x) Arg.(value & flag & info [ "dry-run" ] ~doc)
 
 let yes =
   let doc = "Do not prompt for confirmation and keep going instead" in
-  Arg.(value & flag & info [ "y"; "yes" ] ~doc)
+  named (fun x -> `Yes x) Arg.(value & flag & info [ "y"; "yes" ] ~doc)
 
 (* Terms *)
 

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -14,52 +14,57 @@ open Rresult
 val path_arg : Fpath.t Arg.conv
 (** [path_arg] is a path argument converter. *)
 
-val pkg_names : string list Term.t
+val named : ('a -> 'b) -> 'a Cmdliner.Term.t -> 'b Cmdliner.Term.t
+(** Use this to wrap your arguments in a polymorphic variant constructor to avoid
+    confusion when they are later passed to your main function.
+    Example: [named (fun x -> `My_arg x] Arg.(value ...)] *)
+
+val pkg_names : [ `Package_names of string list ] Term.t
 (** A [--pkg-names] option to specify the packages to release. *)
 
-val pkg_version : string option Term.t
+val pkg_version : [ `Package_version of string option ] Term.t
 (** A [--pkg-version] option to specify the packages version. *)
 
-val keep_v : bool Term.t
+val keep_v : [ `Keep_v of bool ] Term.t
 (** A [--keep-v] option to not drop the 'v' at the beginning of version strings. *)
 
-val dist_name : string option Term.t
+val dist_name : [ `Dist_name of string option ] Term.t
 (** A [--name] option to specify the distribution name. *)
 
-val dist_tag : string option Term.t
+val dist_tag : [ `Dist_tag of string option ] Term.t
 (** A [--tag] option to define the tag to build the distribution from. *)
 
-val dist_file : Fpath.t option Term.t
+val dist_file : [ `Dist_file of Fpath.t option ] Term.t
 (** A [--dist-file] option to define the distribution archive file. *)
 
-val dist_uri : string option Term.t
+val dist_uri : [ `Dist_uri of string option ] Term.t
 (** A [--dist-uri] option to define the distribution archive URI on the WWW. *)
 
-val dist_opam : Fpath.t option Term.t
+val dist_opam : [ `Dist_opam of Fpath.t option ] Term.t
 (** An [--dist-opam] option to define the opam file. *)
 
-val readme : Fpath.t option Term.t
+val readme : [ `Readme of Fpath.t option ] Term.t
 (** A [--readme] option to define the readme. *)
 
-val change_log : Fpath.t option Term.t
+val change_log : [ `Change_log of Fpath.t option ] Term.t
 (** A [--change-log] option to define the change log. *)
 
-val opam : Fpath.t option Term.t
+val opam : [ `Opam of Fpath.t option ] Term.t
 (** An [--opam] option to define an opam file. *)
 
-val build_dir : Fpath.t option Term.t
+val build_dir : [ `Build_dir of Fpath.t option ] Term.t
 (** A [--build-dir] option to define the build directory. *)
 
-val publish_msg : string option Term.t
+val publish_msg : [ `Publish_msg of string option ] Term.t
 (** A [--msg] option to define a publication message. *)
 
-val token : Fpath.t option Term.t
+val token : [ `Token of Fpath.t option ] Term.t
 (** A [--token] option to define the github token. *)
 
-val dry_run : bool Term.t
+val dry_run : [ `Dry_run of bool ] Term.t
 (** A [--dry-run] option to do not perform any action. *)
 
-val yes : bool Term.t
+val yes : [ `Yes of bool ] Term.t
 (** A [--yes] option to skip confirmation prompts. *)
 
 (** {1 Terms} *)

--- a/bin/distrib.ml
+++ b/bin/distrib.ml
@@ -88,8 +88,10 @@ let distrib ?build_dir ~dry_run ~name ~pkg_names ~version ~tag ~keep_v ~keep_dir
   log_footprint pkg ar >>= fun () ->
   (if dry_run then Ok () else warn_if_vcs_dirty ()) >>= fun () -> Ok errs
 
-let distrib_cli () dry_run build_dir name pkg_names version tag keep_v keep_dir
-    skip_lint skip_build skip_tests =
+let distrib_cli () (`Dry_run dry_run) (`Build_dir build_dir) (`Dist_name name)
+    (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
+    (`Keep_v keep_v) (`Keep_dir keep_dir) (`Skip_lint skip_lint)
+    (`Skip_build skip_build) (`Skip_tests skip_tests) =
   distrib ?build_dir ~dry_run ~name ~pkg_names ~version ~tag ~keep_v ~keep_dir
     ~skip_lint ~skip_build ~skip_tests ()
   |> Cli.handle_error
@@ -102,22 +104,30 @@ let keep_build_dir =
   let doc =
     "Keep the distribution build directory after successful archival."
   in
-  Arg.(value & flag & info [ "keep-build-dir" ] ~doc)
+  Cli.named
+    (fun x -> `Keep_dir x)
+    Arg.(value & flag & info [ "keep-build-dir" ] ~doc)
 
 let skip_lint =
   let doc = "Do not lint the archive distribution." in
-  Arg.(value & flag & info [ "skip-lint" ] ~doc)
+  Cli.named
+    (fun x -> `Skip_lint x)
+    Arg.(value & flag & info [ "skip-lint" ] ~doc)
 
 let skip_build =
   let doc = "Do not try to build the package from the archive." in
-  Arg.(value & flag & info [ "skip-build" ] ~doc)
+  Cli.named
+    (fun x -> `Skip_build x)
+    Arg.(value & flag & info [ "skip-build" ] ~doc)
 
 let skip_tests =
   let doc =
     "Do not try to build and run the package tests from the archive. Implied \
      by $(b,--skip-build)."
   in
-  Arg.(value & flag & info [ "skip-tests" ] ~doc)
+  Cli.named
+    (fun x -> `Skip_tests x)
+    Arg.(value & flag & info [ "skip-tests" ] ~doc)
 
 let doc = "Create a package distribution archive"
 

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -7,7 +7,8 @@
 open Bos_setup
 open Dune_release
 
-let lint () dry_run name pkg_names version tag keep_v lints =
+let lint () (`Dry_run dry_run) (`Dist_name name) (`Package_names pkg_names)
+    (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v) (`Lints lints) =
   Cli.handle_error
     ( Config.keep_v keep_v >>= fun keep_v ->
       Pkg.infer_pkg_names Fpath.(v ".") pkg_names >>= fun pkg_names ->
@@ -34,7 +35,9 @@ let lints =
   in
   let test = Arg.enum test in
   let docv = "TEST" in
-  Arg.(value & pos_all test Lint.all & info [] ~doc ~docv)
+  Cli.named
+    (fun x -> `Lints x)
+    Arg.(value & pos_all test Lint.all & info [] ~doc ~docv)
 
 let doc = "Check package distribution consistency and conventions"
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -294,9 +294,14 @@ let submit ?distrib_uri ?local_repo ?remote_repo ?opam_repo ?user ?token
 
 let field ~pkgs ~field_name = field pkgs field_name
 
-let opam_cli () dry_run build_dir local_repo remote_repo opam_repo user keep_v
-    opam distrib_uri distrib_file tag name pkg_names version pkg_descr readme
-    change_log publish_msg action field_name no_auto_open yes token =
+let opam_cli () (`Dry_run dry_run) (`Build_dir build_dir)
+    (`Local_repo local_repo) (`Remote_repo remote_repo) (`Opam_repo opam_repo)
+    (`User user) (`Keep_v keep_v) (`Dist_opam opam) (`Dist_uri distrib_uri)
+    (`Dist_file distrib_file) (`Dist_tag tag) (`Dist_name name)
+    (`Package_names pkg_names) (`Package_version version) (`Pkg_descr pkg_descr)
+    (`Readme readme) (`Change_log change_log) (`Publish_msg publish_msg)
+    (`Action action) (`Field_name field_name) (`No_auto_open no_auto_open)
+    (`Yes yes) (`Token token) =
   get_pkgs ?build_dir ?opam ?distrib_file ?pkg_descr ?readme ?change_log
     ?publish_msg ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
   >>= (fun pkgs ->
@@ -322,37 +327,50 @@ let action =
       (Arg.doc_alts_enum action)
   in
   let action = Arg.enum action in
-  Arg.(required & pos 0 (some action) None & info [] ~doc ~docv:"ACTION")
+  Cli.named
+    (fun x -> `Action x)
+    Arg.(required & pos 0 (some action) None & info [] ~doc ~docv:"ACTION")
 
 let field_arg =
   let doc = "the field to output ($(b,field) action)" in
-  Arg.(value & pos 1 (some string) None & info [] ~doc ~docv:"FIELD")
+  Cli.named
+    (fun x -> `Field_name x)
+    Arg.(value & pos 1 (some string) None & info [] ~doc ~docv:"FIELD")
 
 let no_auto_open =
   let doc = "Do not open a browser to view the new pull-request." in
-  Arg.(value & flag & info [ "no-auto-open" ] ~doc)
+  Cli.named
+    (fun x -> `No_auto_open x)
+    Arg.(value & flag & info [ "no-auto-open" ] ~doc)
 
 let user =
   let doc =
     "the name of the GitHub account where to push new opam-repository branches."
   in
-  Arg.(value & opt (some string) None & info [ "u"; "user" ] ~doc ~docv:"USER")
+  Cli.named
+    (fun x -> `User x)
+    Arg.(
+      value & opt (some string) None & info [ "u"; "user" ] ~doc ~docv:"USER")
 
 let local_repo =
   let doc = "Location of the local fork of opam-repository" in
   let env = Arg.env_var "DUNE_RELEASE_LOCAL_REPO" in
-  Arg.(
-    value
-    & opt (some string) None
-    & info ~env [ "l"; "--local-repo" ] ~doc ~docv:"PATH")
+  Cli.named
+    (fun x -> `Local_repo x)
+    Arg.(
+      value
+      & opt (some string) None
+      & info ~env [ "l"; "--local-repo" ] ~doc ~docv:"PATH")
 
 let remote_repo =
   let doc = "Location of the remote fork of opam-repository" in
   let env = Arg.env_var "DUNE_RELEASE_REMOTE_REPO" in
-  Arg.(
-    value
-    & opt (some string) None
-    & info ~env [ "r"; "--remote-repo" ] ~doc ~docv:"URI")
+  Cli.named
+    (fun x -> `Remote_repo x)
+    Arg.(
+      value
+      & opt (some string) None
+      & info ~env [ "r"; "--remote-repo" ] ~doc ~docv:"URI")
 
 let opam_repo =
   let doc =
@@ -361,10 +379,12 @@ let opam_repo =
   in
   let docv = "GITHUB_USER_OR_ORG/REPO_NAME" in
   let env = Arg.env_var "DUNE_RELEASE_OPAM_REPO" in
-  Arg.(
-    value
-    & opt (some (pair ~sep:'/' string string)) None
-    & info ~env [ "opam-repo" ] ~doc ~docv)
+  Cli.named
+    (fun x -> `Opam_repo x)
+    Arg.(
+      value
+      & opt (some (pair ~sep:'/' string string)) None
+      & info ~env [ "opam-repo" ] ~doc ~docv)
 
 let pkg_descr =
   let doc =
@@ -380,7 +400,9 @@ let pkg_descr =
      'Contact:' or '%%VERSION'."
   in
   let docv = "FILE" in
-  Arg.(value & opt (some Cli.path_arg) None & info [ "pkg-descr" ] ~doc ~docv)
+  Cli.named
+    (fun x -> `Pkg_descr x)
+    Arg.(value & opt (some Cli.path_arg) None & info [ "pkg-descr" ] ~doc ~docv)
 
 let doc = "Interaction with opam and the OCaml opam repository"
 

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -85,9 +85,12 @@ let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
   in
   List.fold_left publish_artefact (Ok ()) publish_artefacts >>= fun () -> Ok 0
 
-let publish_cli () build_dir name pkg_names version tag keep_v opam delegate
-    change_log distrib_uri distrib_file publish_msg dry_run publish_artefacts
-    yes token =
+let publish_cli () (`Build_dir build_dir) (`Dist_name name)
+    (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
+    (`Keep_v keep_v) (`Dist_opam opam) (`Delegate delegate)
+    (`Change_log change_log) (`Dist_uri distrib_uri) (`Dist_file distrib_file)
+    (`Publish_msg publish_msg) (`Dry_run dry_run)
+    (`Publish_artefacts publish_artefacts) (`Yes yes) (`Token token) =
   publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
     ?publish_msg ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
     ~publish_artefacts ~yes ()
@@ -106,9 +109,11 @@ let delegate =
   in
   let docv = "TOOL" in
   let to_cmd = function None -> None | Some s -> Some (Cmd.v s) in
-  Term.(
-    const to_cmd
-    $ Arg.(value & opt (some string) None & info [ "delegate" ] ~doc ~docv))
+  Cli.named
+    (fun x -> `Delegate x)
+    Term.(
+      const to_cmd
+      $ Arg.(value & opt (some string) None & info [ "delegate" ] ~doc ~docv))
 
 let artefacts =
   let alt_prefix = "alt-" in
@@ -135,7 +140,9 @@ let artefacts =
        absent, the set of default publication artefacts is determined by the \
        package description."
   in
-  Arg.(value & pos_all artefact [] & info [] ~doc ~docv:"ARTEFACT")
+  Cli.named
+    (fun x -> `Publish_artefacts x)
+    Arg.(value & pos_all artefact [] & info [] ~doc ~docv:"ARTEFACT")
 
 let doc =
   Deprecate_delegates.artefacts_warning

--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -70,7 +70,9 @@ let vcs_tag pkg tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg ~yes =
           m "Tagged %a with version %a" Text.Pp.commit commit_ish
             Text.Pp.version tag)
 
-let tag () dry_run name change_log tag commit_ish force sign delete msg yes =
+let tag () (`Dry_run dry_run) (`Dist_name name) (`Change_log change_log)
+    (`Version tag) (`Commit_ish commit_ish) (`Force force) (`Sign sign)
+    (`Delete delete) (`Msg msg) (`Yes yes) =
   (let pkg = Pkg.v ~dry_run ?change_log ?name () in
    let tag =
      match tag with
@@ -99,31 +101,39 @@ let version =
     "The version tag to use. If absent, automatically extracted from the \
      package's change log."
   in
-  Arg.(value & pos 0 (some string) None & info [] ~doc ~docv:"VERSION")
+  Cli.named
+    (fun x -> `Version x)
+    Arg.(value & pos 0 (some string) None & info [] ~doc ~docv:"VERSION")
 
 let commit =
   let doc = "Commit-ish $(docv) to tag." in
-  Arg.(value & opt string "HEAD" & info [ "commit" ] ~doc ~docv:"COMMIT-ISH")
+  Cli.named
+    (fun x -> `Commit_ish x)
+    Arg.(value & opt string "HEAD" & info [ "commit" ] ~doc ~docv:"COMMIT-ISH")
 
 let msg =
   let doc =
     "Commit message for the tag. If absent, the message 'Distribution \
      $(i,VERSION)' is used."
   in
-  Arg.(
-    value & opt (some string) None & info [ "m"; "message" ] ~doc ~docv:"MSG")
+  Cli.named
+    (fun x -> `Msg x)
+    Arg.(
+      value & opt (some string) None & info [ "m"; "message" ] ~doc ~docv:"MSG")
 
 let sign =
   let doc = "Sign the tag using the VCS's default signing key." in
-  Arg.(value & flag & info [ "s"; "sign" ] ~doc)
+  Cli.named (fun x -> `Sign x) Arg.(value & flag & info [ "s"; "sign" ] ~doc)
 
 let force =
   let doc = "If the tag exists, replace it rather than fail." in
-  Arg.(value & flag & info [ "f"; "force" ] ~doc)
+  Cli.named (fun x -> `Force x) Arg.(value & flag & info [ "f"; "force" ] ~doc)
 
 let delete =
   let doc = "Delete the specified tag rather than create it." in
-  Arg.(value & flag & info [ "d"; "delete" ] ~doc)
+  Cli.named
+    (fun x -> `Delete x)
+    Arg.(value & flag & info [ "d"; "delete" ] ~doc)
 
 let doc = "Tag the package's source repository with a version"
 


### PR DESCRIPTION
We're using this trick from @CraigFe in duniverse and I thought it'd be a good idea to use it here as well, especially considering the number of args some commands have.

Let me know what you think!