### PR TITLE
Simplify distrib tarball preparation

### DIFF
--- a/lib/distrib.ml
+++ b/lib/distrib.ml
@@ -4,38 +4,19 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-open Rresult
+let default_exclude_paths =
+  List.map Fpath.v
+    [
+      ".git";
+      ".gitignore";
+      ".gitattributes";
+      ".hg";
+      ".hgignore";
+      "build";
+      "_build";
+    ]
 
-(* Defaults *)
-
-let default_exclude_paths () =
-  let l =
-    List.map Fpath.v
-      [
-        ".git";
-        ".gitignore";
-        ".gitattributes";
-        ".hg";
-        ".hgignore";
-        "build";
-        "_build";
-      ]
-  in
-  Ok l
-
-(* Distribution *)
-
-type t = {
-  massage : unit -> (unit, R.msg) result;
-  exclude_paths : unit -> (Fpath.t list, R.msg) result;
-}
-
-let v ?(massage = fun () -> Ok ()) ?(exclude_paths = default_exclude_paths) () =
-  { massage; exclude_paths }
-
-let massage d = d.massage
-
-let exclude_paths d = d.exclude_paths
+let exclude_paths = default_exclude_paths
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/distrib.mli
+++ b/lib/distrib.mli
@@ -4,38 +4,8 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-(** {1 Distribution description} *)
-
-open Rresult
-
-(** {1:distrib Distribution description} *)
-
-type t
-(** The type for describing distribution creation. *)
-
-val v :
-  ?massage:(unit -> (unit, R.msg) result) ->
-  ?exclude_paths:(unit -> (Fpath.t list, R.msg) result) ->
-  unit ->
-  t
-(** [distrib ~massage ~exclude_paths ()] influences the distribution creation
-    process performed by the [dune-release] tool. See the {{!distdetails} full
-    details about distribution creation}.
-
-    In the following the {e distribution build directory} is a private clone of
-    the package's source repository's [HEAD] when [dune-release distrib] is
-    invoked.
-
-    - [massage] is invoked in the distribution build directory, before
-      archiving. It can be used to generate distribution time build artefacts.
-      Defaults to {!massage}.
-    - [exclude_paths ()] is invoked in the distribution build directory, after
-      massaging, to determine the paths that are excluded from being added to
-      the distribution archive. Defaults to {!exclude_paths}. *)
-
-val massage : t -> unit -> (unit, R.msg) result
-
-val exclude_paths : t -> unit -> (Fpath.t list, R.msg) result
+val exclude_paths : Fpath.t list
+(** List of paths to exclude from the distribution tarball *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -43,7 +43,6 @@ type t = {
   readmes : Fpath.t list option;
   change_logs : Fpath.t list option;
   licenses : Fpath.t list option;
-  distrib : Distrib.t;
   distrib_file : Fpath.t option;
   publish_msg : string option;
 }
@@ -443,7 +442,7 @@ let infer_name dir =
 
 let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir
     ?opam:opam_file ?opam_descr ?readme ?change_log ?license ?distrib_file
-    ?publish_msg ?(distrib = Distrib.v ()) () =
+    ?publish_msg () =
   let name =
     match name with None -> infer_name Fpath.(v ".") | Some v -> Ok v
   in
@@ -470,7 +469,6 @@ let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir
       licenses;
       distrib_file;
       publish_msg;
-      distrib;
     }
   in
   p
@@ -505,13 +503,11 @@ let distrib_version_opam_files ~dry_run ~version =
       let content = prepare_opam_for_distrib ~version ~content in
       Sos.write_file ~dry_run file (String.concat ~sep:"\n" content))
 
-let distrib_prepare ~dry_run p ~dist_build_dir ~version =
-  let d = p.distrib in
+let distrib_prepare ~dry_run ~dist_build_dir ~version =
   Sos.with_dir ~dry_run dist_build_dir
     (fun () ->
       Sos.run ~dry_run Cmd.(v "dune" % "subst") >>= fun () ->
-      distrib_version_opam_files ~dry_run ~version >>= fun () ->
-      Distrib.massage d () >>= fun () -> Distrib.exclude_paths d ())
+      distrib_version_opam_files ~dry_run ~version)
     ()
   |> R.join
 
@@ -534,8 +530,8 @@ let distrib_archive ~dry_run ~keep_dir p =
   Vcs.get ~dir:dist_build_dir () >>= fun clone ->
   Ok (Fmt.strf "dune-release-dist-%s" tag) >>= fun branch ->
   Vcs.checkout ~dry_run clone ~branch ~commit_ish:tag >>= fun () ->
-  distrib_prepare ~dry_run p ~dist_build_dir ~version >>= fun exclude_paths ->
-  let exclude_paths = Fpath.Set.of_list exclude_paths in
+  distrib_prepare ~dry_run ~dist_build_dir ~version >>= fun () ->
+  let exclude_paths = Fpath.Set.of_list Distrib.exclude_paths in
   Archive.tar dist_build_dir ~exclude_paths ~root ~mtime >>= fun tar ->
   distrib_archive_path p >>= fun archive ->
   Archive.bzip2 ~dry_run ~force:true ~dst:archive tar >>= fun () ->

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -28,7 +28,6 @@ val v :
   ?license:Fpath.t ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
-  ?distrib:Distrib.t ->
   unit ->
   t
 


### PR DESCRIPTION
This used to rely on Distrib.t which was in fact never instantiated to anything than the default value. This simplifies this module to a static list of paths to exclude for now.

Eventually we'll move some `Pkg` functions there but for now I mostly wanted to get rid of all the indirections.