### PR TITLE
Remove the 'licenses' field from Pkg

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -12,10 +12,13 @@ type std_file = {
   get_path : Pkg.t -> (Fpath.t list, R.msg) result;
 }
 
+let licenses () =
+  Sos.find_files (Fpath.v ".") ~names_wo_ext:[ "license"; "copying" ]
+
 let std_files =
   [
     { generic_name = "README"; get_path = Pkg.readmes };
-    { generic_name = "LICENSE"; get_path = Pkg.licenses };
+    { generic_name = "LICENSE"; get_path = (fun _ -> licenses ()) };
     { generic_name = "CHANGES"; get_path = Pkg.change_logs };
     {
       generic_name = "opam";

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -25,7 +25,6 @@ val v :
   ?opam_descr:Fpath.t ->
   ?readme:Fpath.t ->
   ?change_log:Fpath.t ->
-  ?license:Fpath.t ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
   unit ->
@@ -75,9 +74,6 @@ val change_logs : t -> (Fpath.t list, R.msg) result
 
 val change_log : t -> (Fpath.t, R.msg) result
 (** [change_log p] is the first element of [change_logs p]. *)
-
-val licenses : t -> (Fpath.t list, R.msg) result
-(** [licenses p] are [p]'s license files. *)
 
 val infer_distrib_uri : t -> (string, R.msg) result
 (** [infer_distrib_uri p] infers [p]'s distribution URI from the homepage and

--- a/lib/sos.ml
+++ b/lib/sos.ml
@@ -224,3 +224,7 @@ let relativize ~src ~dst =
     ~none:(fun () ->
       R.error_msgf "Could define path from %a to %a" Fpath.pp src Fpath.pp dst)
     (Fpath.relativize ~root:src dst)
+
+let find_files path ~names_wo_ext =
+  OS.Dir.contents path >>| fun files ->
+  Stdext.Path.find_files files ~names_wo_ext

--- a/lib/sos.mli
+++ b/lib/sos.mli
@@ -132,3 +132,6 @@ val relativize : src:Fpath.t -> dst:Fpath.t -> (Fpath.t, error) result
 (** [relativize ~src ~dst] return a relative path from [src] to [dst]. If such a
     path can't be expressed, i.e. [srs] and [dst] don't have a common root,
     returns an error. *)
+
+val find_files :
+  Fpath.t -> names_wo_ext:string list -> (Fpath.t list, error) result


### PR DESCRIPTION
Exporting non- `pkg.t`-specific functions to sos.ml. No behavioral change.