### PR TITLE
Fix a bug excluding all root dotfiles from the generated distrib tarball

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
   (#266, @NathanReb)
 - Improve trimming of the changelog to preserve the indentation of the list of changes. (#268, @gpetiot)
 - Trim the data of the `url` file before filling the `url.src` field. This fixes an issue that caused the `url.src` field to be a multi-line string instead of single line. (#270, @gpetiot)
+- Fix a bug causing dune-release to exclude all hidden files and folders (starting with `.`) at the
+  repository from the distrib archive (#298, @NathanReb)
 
 ### Security
 

--- a/lib/archive.ml
+++ b/lib/archive.ml
@@ -124,8 +124,9 @@ let path_set_of_dir dir ~exclude_paths =
   let traverse = `Sat not_excluded in
   let elements = `Sat not_excluded in
   let err _ e = e in
-  OS.Dir.fold_contents ~dotfiles:true ~err ~elements ~traverse Fpath.Set.add
-    Fpath.Set.empty dir
+  OS.Dir.contents ~dotfiles:true dir
+  >>= OS.Path.fold ~dotfiles:true ~err ~elements ~traverse Fpath.Set.add
+        Fpath.Set.empty
 
 let tar dir ~exclude_paths ~root ~mtime =
   let tar_add file tar =

--- a/tests/bin/include-versioned-dotfiles/dune
+++ b/tests/bin/include-versioned-dotfiles/dune
@@ -1,0 +1,3 @@
+(mdx
+ (files run.t)
+ (packages dune-release))

--- a/tests/bin/include-versioned-dotfiles/run.t
+++ b/tests/bin/include-versioned-dotfiles/run.t
@@ -1,0 +1,47 @@
+We need a basic opam project skeleton
+
+    $ cat > CHANGES.md << EOF \
+    > ## 0.1.0\
+    > \
+    > - Some other feature\
+    > \
+    > ## 0.0.0\
+    > \
+    > - Some feature\
+    > EOF
+    $ touch whatever.opam
+    $ cat > dune-project << EOF \
+    > (lang dune 2.4)\
+    > (name whatever)\
+    > EOF
+    $ cat > .gitignore << EOF \
+    > _build\
+    > run.t*\
+    > EOF
+
+We also need a dotfile that we will properly version
+
+  $ echo "hello" > .somedotfile
+
+We need to set up a git project for dune-release to work properly
+
+    $ git init > /dev/null
+    $ git add CHANGES.md whatever.opam dune-project .somedotfile .gitignore
+    $ git commit -m "Initial commit" > /dev/null
+    $ dune-release tag -y
+    [-] Extracting tag from first entry in CHANGES.md
+    [-] Using tag "0.1.0"
+    [+] Tagged HEAD with version 0.1.0
+
+The generated tarball should contain the dotfile
+
+    $ dune-release distrib --skip-lint --skip-build --skip-test
+    [-] Building source archive
+    [+] Wrote archive _build/whatever-0.1.0.tbz
+    
+    [+] Distribution for whatever 0.1.0
+    [+] Commit ...
+    [+] Archive _build/whatever-0.1.0.tbz
+    $ tar -xjf _build/whatever-0.1.0.tbz
+    $ cat whatever-0.1.0/.somedotfile
+    hello


### PR DESCRIPTION
`Bos.OS.Dir.fold_contents` behaviour though following its spec is very counter intuitive since specifying `~dotfiles:true` will only include dotfiles and folders in subdirectories.

Luckily this hasn't broken anything yet but it is obviously a bad behaviour that needed fixing. The fact that we maintain an explicit
list of files and folders to exclude from the archive, some of which are root dotfiles and folders confirms that this behaviour was not intentional.