### PR TITLE
Include versioned files to the archive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 - Attach the changelog to the annotated tag message (#283, @gpetiot)
 - Deprecate the use of delegates in `dune-release publish` (#276, @pitag-ha)
+- Do not remove versioned files from the tarball anymore. We used to exclude
+  `.gitignore`, `.gitattributes` and other such files from the archive.
+  (#299, @NathanReb)
 
 ### Deprecated
 

--- a/lib/distrib.ml
+++ b/lib/distrib.ml
@@ -4,17 +4,7 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-let default_exclude_paths =
-  List.map Fpath.v
-    [
-      ".git";
-      ".gitignore";
-      ".gitattributes";
-      ".hg";
-      ".hgignore";
-      "build";
-      "_build";
-    ]
+let default_exclude_paths = List.map Fpath.v [ ".git"; ".hg" ]
 
 let exclude_paths = default_exclude_paths
 


### PR DESCRIPTION
Those special rules resulted in removing versioned files in the archive. There's no need for special treatment of build dirs since those shouldn't be versioned anyway and therefore won't be included in the archive since we go through a clone and a checkout before building the tarball.