### PR TITLE
Add more ellipses to the `no-doc` cram test

### DIFF
--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -229,9 +229,11 @@ We do the whole process, calling publish doc implicitely should succeed
     [-] Preparing pull request to ocaml/opam-repository
     ...
     [-] Fetching https://github.com/ocaml/opam-repository.git#master
+    ...
     => exec:
          git --git-dir .git fetch https://github.com/ocaml/opam-repository.git master
     => exec: git --git-dir .git rev-parse FETCH_HEAD
+    ...
     [-] Checking out a local release-whatever-0.1.0 branch
     => exec: git --git-dir .git add packages/whatever/whatever.0.1.0
     => exec: git --git-dir .git add packages/whatever-lib/whatever-lib.0.1.0


### PR DESCRIPTION
   
It seems like the `no-doc`-test isn't fully deterministic. This commit
adds a couple of ellipses that are necessary for it to pass on some
environments.