### PR TITLE
Set the default tag message to "Release <tag>" instead of "Distribution <tag>"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
   tarball (#300, @NathanReb)
 - Make the automatic dune-release workflow to stop if a step exits with a non-zero code (#332, @gpetiot)
 - Make git-related mdx tests more robust in unusual environments (#334, @sternenseemann)
+- Set the default tag message to "Release <tag>" instead of "Distribution <tag>"
 
 ### Deprecated
 

--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -65,7 +65,7 @@ let vcs_tag repo pkg version ~dry_run ~commit_ish ~force ~sign ~delete ~msg ~yes
       | Some msg -> Ok msg
       | None ->
           Pkg.publish_msg pkg >>| fun msg ->
-          strf "Distribution %s\n\n%s" version msg)
+          strf "Release %s\n\n%s" version msg)
       >>= fun msg ->
       Vcs.tag repo ~dry_run ~force ~sign ~msg ~commit_ish tag >>| fun () ->
       App_log.success (fun m ->

--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -64,8 +64,7 @@ let vcs_tag repo pkg version ~dry_run ~commit_ish ~force ~sign ~delete ~msg ~yes
       (match msg with
       | Some msg -> Ok msg
       | None ->
-          Pkg.publish_msg pkg >>| fun msg ->
-          strf "Release %s\n\n%s" version msg)
+          Pkg.publish_msg pkg >>| fun msg -> strf "Release %s\n\n%s" version msg)
       >>= fun msg ->
       Vcs.tag repo ~dry_run ~force ~sign ~msg ~commit_ish tag >>| fun () ->
       App_log.success (fun m ->

--- a/tests/bin/tag/run.t
+++ b/tests/bin/tag/run.t
@@ -39,7 +39,7 @@ Checking the message attached to the tag.
     Tagger: ...
     Date:   ...
     
-    Distribution 0.1.0
+    Release 0.1.0
     
     CHANGES:
     


### PR DESCRIPTION
When making a release, the default title dune-release will give it when calling `dune-release tag` is `Distribution <tag>`.
This title will be carried on in the github UI:
![scrn-2020-10-24-02-22-46](https://user-images.githubusercontent.com/2611789/97064708-d99f2100-159f-11eb-8255-7ae583dd8abe.png)
However I feel like this is a bit surprising. I feel like "distribution" doesn't quite convey the right meaning and "release" feels more right in the default case.