### PR TITLE
Suggest a solution for users without ssh set up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Log curl calls on verbose/debug mode (#281, @gpetiot)
 - Try to publish the release asset again after it failed (#272, @gpetiot)
 - Improve error reporting of failing git comands (#257, @gpetiot)
+- Suggest a solution for users without ssh setup ( #304, @pitag-ha)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ The full documentation of this command is available with
 dune-release help publish
 ```
 
+## Publish troubleshooting
+
+If github returns a `Permission denied` error during `dune-release publish`, the reason is probably a failing ssh connection. In that case, we suggest that you set up ssh. If you prefer not to and you've already set up https instead, we suggest that you configure git as follows:
+```
+git config [--global] url."https://github.com/".pushInsteadOf "git@github.com:"
+```
+Running that line once will configure git to always push over https - either for that repository or globally.
+
+In more detail: `dune-release publish` always pushes to github over ssh by explicitly giving git the github uri of your project with ssh prefix (`git@github.com:`). By configuring git as suggested above, git will automatically replace that prefix by the https one when pushing and push over https instead.
 
 ### Create an opam package and submit it to the opam repository
 

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -62,6 +62,16 @@ let run_git ~dry_run ?force ~default r args out =
   >>= fun response ->
   match response.status with
   | `Exited 0 -> Ok response.output
+  | `Exited 128
+    when String.is_prefix response.err_msg
+           ~affix:"git@github.com: Permission denied" ->
+      let hint =
+        "\n\
+         Hint from dune-release: the reason for the Permission denied error is \
+         probably a failing ssh connection. For more information, see \
+         https://github.com/ocamllabs/dune-release#publish-troubleshooting ."
+      in
+      Sos.cmd_error git (Some (response.err_msg ^ hint)) response.status
   | _ -> Sos.cmd_error git (Some response.err_msg) response.status
 
 let run_git_quiet ~dry_run ?force r args =


### PR DESCRIPTION
Users who haven't set up ssh will get a Permission denied error from
github when using `dune-release publish`. This commit adds to the README
how the user can configure git in order to solve that problem. It also
adds a hint to the Permission denied error message pointing to that
new part of the README.

Closes #212