### PR TITLE
Remove option --name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@
 
 ### Removed
 
+- Option --name is removed from all commands. When used with
+  `dune-release distrib`, it was previously effectively ignored. The
+  alternative is to add a `(name <name>)` stanza to
+  `dune-project`. (#324, @lehy)
+
 ### Fixed
 
 - Fix the priority of the `--distrib-uri` option in `dune-release opam pkg`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,9 +29,9 @@
 ### Removed
 
 - Option --name is removed from all commands. When used with
-  `dune-release distrib`, it was previously effectively ignored. The
-  alternative is to add a `(name <name>)` stanza to
-  `dune-project`. (#324, @lehy)
+  `dune-release distrib`, it was previously effectively ignored. Now
+  it is required to add a `(name <name>)` stanza to
+  `dune-project`. (#327, @lehy)
 
 ### Fixed
 

--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -6,20 +6,19 @@
 
 open Bos_setup.R.Infix
 
-let bistro () (`Dry_run dry_run) (`Dist_name name) (`Package_names pkg_names)
+let bistro () (`Dry_run dry_run) (`Package_names pkg_names)
     (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v) (`Token token)
     (`Include_submodules include_submodules) =
   Cli.handle_error
     ( Dune_release.Config.keep_v keep_v >>= fun keep_v ->
-      Distrib.distrib ~dry_run ~name ~pkg_names ~version ~tag ~keep_v
-        ~keep_dir:false ~skip_lint:false ~skip_build:false ~skip_tests:false
-        ~include_submodules ()
+      Distrib.distrib ~dry_run ~pkg_names ~version ~tag ~keep_v ~keep_dir:false
+        ~skip_lint:false ~skip_build:false ~skip_tests:false ~include_submodules
+        ()
       >>= fun _distrib_ret ->
-      Publish.publish ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
+      Publish.publish ?token ~pkg_names ~version ~tag ~keep_v ~dry_run
         ~publish_artefacts:[] ~yes:false ()
       >>= fun _publish_ret ->
-      Opam.get_pkgs ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
-      >>= fun pkgs ->
+      Opam.get_pkgs ~dry_run ~keep_v ~tag ~pkg_names ~version () >>= fun pkgs ->
       Opam.pkg ~dry_run ~pkgs () >>= fun _opam_pkg_ret ->
       Opam.submit ?token ~dry_run ~pkgs ~pkg_names ~no_auto_open:false
         ~yes:false ()
@@ -51,9 +50,8 @@ let man =
 
 let cmd =
   ( Term.(
-      pure bistro $ Cli.setup $ Cli.dry_run $ Cli.dist_name $ Cli.pkg_names
-      $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v $ Cli.token
-      $ Cli.include_submodules),
+      pure bistro $ Cli.setup $ Cli.dry_run $ Cli.pkg_names $ Cli.pkg_version
+      $ Cli.dist_tag $ Cli.keep_v $ Cli.token $ Cli.include_submodules),
     Term.info "bistro" ~doc ~sdocs ~exits ~man ~man_xrefs )
 
 (*---------------------------------------------------------------------------

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -23,18 +23,6 @@ let dist_tag =
     Arg.(
       value & opt (some string) None & info [ "t"; "tag" ] ~doc ~docv:"DIST_TAG")
 
-let dist_name =
-  let doc =
-    "The name $(docv) of the distribution. If absent provided by i)   the \
-     $(i,name) field in $(b,dune-project); ii)  the longest prefix of all the \
-     $(b,*.opam) files present in the current directory; and iii) the first \
-     word in the title of $(b,README.md)."
-  in
-  let docv = "DIST_NAME" in
-  named
-    (fun x -> `Dist_name x)
-    Arg.(value & opt (some string) None & info [ "n"; "name" ] ~doc ~docv)
-
 let pkg_names =
   let doc =
     "The names $(docv) of the opam packages to release. If absent provided by \

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -28,9 +28,6 @@ val pkg_version : [ `Package_version of string option ] Term.t
 val keep_v : [ `Keep_v of bool ] Term.t
 (** A [--keep-v] option to not drop the 'v' at the beginning of version strings. *)
 
-val dist_name : [ `Dist_name of string option ] Term.t
-(** A [--name] option to specify the distribution name. *)
-
 val dist_tag : [ `Dist_tag of string option ] Term.t
 (** A [--tag] option to define the tag to build the distribution from. *)
 

--- a/bin/distrib.ml
+++ b/bin/distrib.ml
@@ -76,11 +76,11 @@ let log_wrote_archive ar =
   App_log.success (fun m -> m "Wrote archive %a" Text.Pp.path ar);
   Ok ()
 
-let distrib ?build_dir ~dry_run ~name ~pkg_names ~version ~tag ~keep_v ~keep_dir
+let distrib ?build_dir ~dry_run ~pkg_names ~version ~tag ~keep_v ~keep_dir
     ~skip_lint ~skip_build ~skip_tests ~include_submodules () =
   App_log.status (fun l -> l "Building source archive");
   Config.keep_v keep_v >>= fun keep_v ->
-  let pkg = Pkg.v ~dry_run ?name ?version ~keep_v ?build_dir ?tag () in
+  let pkg = Pkg.v ~dry_run ?version ~keep_v ?build_dir ?tag () in
   Pkg.distrib_archive ~dry_run ~keep_dir ~include_submodules pkg >>= fun ar ->
   log_wrote_archive ar >>= fun () ->
   check_archive ~dry_run ~skip_lint ~skip_build ~skip_tests ~pkg_names pkg ar
@@ -88,12 +88,12 @@ let distrib ?build_dir ~dry_run ~name ~pkg_names ~version ~tag ~keep_v ~keep_dir
   log_footprint pkg ar >>= fun () ->
   (if dry_run then Ok () else warn_if_vcs_dirty ()) >>= fun () -> Ok errs
 
-let distrib_cli () (`Dry_run dry_run) (`Build_dir build_dir) (`Dist_name name)
+let distrib_cli () (`Dry_run dry_run) (`Build_dir build_dir)
     (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
     (`Keep_v keep_v) (`Keep_dir keep_dir) (`Skip_lint skip_lint)
     (`Skip_build skip_build) (`Skip_tests skip_tests)
     (`Include_submodules include_submodules) =
-  distrib ?build_dir ~dry_run ~name ~pkg_names ~version ~tag ~keep_v ~keep_dir
+  distrib ?build_dir ~dry_run ~pkg_names ~version ~tag ~keep_v ~keep_dir
     ~skip_lint ~skip_build ~skip_tests ~include_submodules ()
   |> Cli.handle_error
 
@@ -205,10 +205,9 @@ let man =
 
 let cmd =
   ( Term.(
-      pure distrib_cli $ Cli.setup $ Cli.dry_run $ Cli.build_dir $ Cli.dist_name
-      $ Cli.pkg_names $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v
-      $ keep_build_dir $ skip_lint $ skip_build $ skip_tests
-      $ Cli.include_submodules),
+      pure distrib_cli $ Cli.setup $ Cli.dry_run $ Cli.build_dir $ Cli.pkg_names
+      $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v $ keep_build_dir $ skip_lint
+      $ skip_build $ skip_tests $ Cli.include_submodules),
     Term.info "distrib" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs )
 
 (*---------------------------------------------------------------------------

--- a/bin/distrib.mli
+++ b/bin/distrib.mli
@@ -9,7 +9,6 @@
 val distrib :
   ?build_dir:Fpath.t ->
   dry_run:bool ->
-  name:string option ->
   pkg_names:string list ->
   version:string option ->
   tag:string option ->

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -7,12 +7,12 @@
 open Bos_setup
 open Dune_release
 
-let lint () (`Dry_run dry_run) (`Dist_name name) (`Package_names pkg_names)
+let lint () (`Dry_run dry_run) (`Package_names pkg_names)
     (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v) (`Lints lints) =
   Cli.handle_error
     ( Config.keep_v keep_v >>= fun keep_v ->
       Pkg.infer_pkg_names Fpath.(v ".") pkg_names >>= fun pkg_names ->
-      let pkg = Pkg.v ~dry_run ?name ?version ~keep_v ?tag () in
+      let pkg = Pkg.v ~dry_run ?version ~keep_v ?tag () in
       OS.Dir.current () >>= fun dir ->
       List.fold_left
         (fun acc name ->
@@ -63,8 +63,8 @@ let man =
 
 let cmd =
   ( Term.(
-      pure lint $ Cli.setup $ Cli.dry_run $ Cli.dist_name $ Cli.pkg_names
-      $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v $ lints),
+      pure lint $ Cli.setup $ Cli.dry_run $ Cli.pkg_names $ Cli.pkg_version
+      $ Cli.dist_tag $ Cli.keep_v $ lints),
     Term.info "lint" ~doc ~sdocs ~exits ~man ~man_xrefs )
 
 (*---------------------------------------------------------------------------

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -237,11 +237,11 @@ let field pkgs field =
 (* Command *)
 
 let get_pkgs ?build_dir ?opam ?distrib_file ?readme ?change_log ?publish_msg
-    ?pkg_descr ~dry_run ~keep_v ~tag ~name ~pkg_names ~version () =
+    ?pkg_descr ~dry_run ~keep_v ~tag ~pkg_names ~version () =
   Config.keep_v keep_v >>= fun keep_v ->
   let distrib_file =
     let pkg =
-      Pkg.v ?name ?opam ?tag ?version ?distrib_file ~dry_run:false ~keep_v ()
+      Pkg.v ?opam ?tag ?version ?distrib_file ~dry_run:false ~keep_v ()
     in
     Pkg.distrib_file ~dry_run pkg
   in
@@ -297,13 +297,13 @@ let field ~pkgs ~field_name = field pkgs field_name
 let opam_cli () (`Dry_run dry_run) (`Build_dir build_dir)
     (`Local_repo local_repo) (`Remote_repo remote_repo) (`Opam_repo opam_repo)
     (`User user) (`Keep_v keep_v) (`Dist_opam opam) (`Dist_uri distrib_uri)
-    (`Dist_file distrib_file) (`Dist_tag tag) (`Dist_name name)
-    (`Package_names pkg_names) (`Package_version version) (`Pkg_descr pkg_descr)
-    (`Readme readme) (`Change_log change_log) (`Publish_msg publish_msg)
-    (`Action action) (`Field_name field_name) (`No_auto_open no_auto_open)
-    (`Yes yes) (`Token token) =
+    (`Dist_file distrib_file) (`Dist_tag tag) (`Package_names pkg_names)
+    (`Package_version version) (`Pkg_descr pkg_descr) (`Readme readme)
+    (`Change_log change_log) (`Publish_msg publish_msg) (`Action action)
+    (`Field_name field_name) (`No_auto_open no_auto_open) (`Yes yes)
+    (`Token token) =
   get_pkgs ?build_dir ?opam ?distrib_file ?pkg_descr ?readme ?change_log
-    ?publish_msg ~dry_run ~keep_v ~tag ~name ~pkg_names ~version ()
+    ?publish_msg ~dry_run ~keep_v ~tag ~pkg_names ~version ()
   >>= (fun pkgs ->
         match action with
         | `Descr -> descr ~pkgs
@@ -446,10 +446,10 @@ let cmd =
     Term.(
       pure opam_cli $ Cli.setup $ Cli.dry_run $ Cli.build_dir $ local_repo
       $ remote_repo $ opam_repo $ user $ Cli.keep_v $ Cli.dist_opam
-      $ Cli.dist_uri $ Cli.dist_file $ Cli.dist_tag $ Cli.dist_name
-      $ Cli.pkg_names $ Cli.pkg_version $ pkg_descr $ Cli.readme
-      $ Cli.change_log $ Cli.publish_msg $ action $ field_arg $ no_auto_open
-      $ Cli.yes $ Cli.token)
+      $ Cli.dist_uri $ Cli.dist_file $ Cli.dist_tag $ Cli.pkg_names
+      $ Cli.pkg_version $ pkg_descr $ Cli.readme $ Cli.change_log
+      $ Cli.publish_msg $ action $ field_arg $ no_auto_open $ Cli.yes
+      $ Cli.token)
   in
   (t, info)
 

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -17,7 +17,6 @@ val get_pkgs :
   dry_run:bool ->
   keep_v:bool ->
   tag:string option ->
-  name:string option ->
   pkg_names:string list ->
   version:string option ->
   unit ->

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -63,7 +63,7 @@ let publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg =
   Delegate.publish_distrib ?token ?distrib_uri ~dry_run ~yes pkg ~msg ~archive
 
 let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
-    ?publish_msg ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
+    ?publish_msg ?token ~pkg_names ~version ~tag ~keep_v ~dry_run
     ~publish_artefacts ~yes () =
   let specific_doc =
     List.exists (function `Doc -> true | _ -> false) publish_artefacts
@@ -73,7 +73,7 @@ let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
   in
   Config.keep_v keep_v >>= fun keep_v ->
   let pkg =
-    Pkg.v ~dry_run ?name ?version ?tag ~keep_v ?build_dir ?opam ?change_log
+    Pkg.v ~dry_run ?version ?tag ~keep_v ?build_dir ?opam ?change_log
       ?distrib_file ?publish_msg ?delegate ()
   in
   let publish_artefact acc artefact =
@@ -85,14 +85,14 @@ let publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
   in
   List.fold_left publish_artefact (Ok ()) publish_artefacts >>= fun () -> Ok 0
 
-let publish_cli () (`Build_dir build_dir) (`Dist_name name)
-    (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
-    (`Keep_v keep_v) (`Dist_opam opam) (`Delegate delegate)
-    (`Change_log change_log) (`Dist_uri distrib_uri) (`Dist_file distrib_file)
-    (`Publish_msg publish_msg) (`Dry_run dry_run)
-    (`Publish_artefacts publish_artefacts) (`Yes yes) (`Token token) =
+let publish_cli () (`Build_dir build_dir) (`Package_names pkg_names)
+    (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v)
+    (`Dist_opam opam) (`Delegate delegate) (`Change_log change_log)
+    (`Dist_uri distrib_uri) (`Dist_file distrib_file) (`Publish_msg publish_msg)
+    (`Dry_run dry_run) (`Publish_artefacts publish_artefacts) (`Yes yes)
+    (`Token token) =
   publish ?build_dir ?opam ?delegate ?change_log ?distrib_uri ?distrib_file
-    ?publish_msg ?token ~name ~pkg_names ~version ~tag ~keep_v ~dry_run
+    ?publish_msg ?token ~pkg_names ~version ~tag ~keep_v ~dry_run
     ~publish_artefacts ~yes ()
   |> Cli.handle_error
 
@@ -179,10 +179,10 @@ let man =
 
 let cmd =
   ( Term.(
-      pure publish_cli $ Cli.setup $ Cli.build_dir $ Cli.dist_name
-      $ Cli.pkg_names $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v
-      $ Cli.dist_opam $ delegate $ Cli.change_log $ Cli.dist_uri $ Cli.dist_file
-      $ Cli.publish_msg $ Cli.dry_run $ artefacts $ Cli.yes $ Cli.token),
+      pure publish_cli $ Cli.setup $ Cli.build_dir $ Cli.pkg_names
+      $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v $ Cli.dist_opam $ delegate
+      $ Cli.change_log $ Cli.dist_uri $ Cli.dist_file $ Cli.publish_msg
+      $ Cli.dry_run $ artefacts $ Cli.yes $ Cli.token),
     Term.info "publish" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs )
 
 (*---------------------------------------------------------------------------

--- a/bin/publish.mli
+++ b/bin/publish.mli
@@ -15,7 +15,6 @@ val publish :
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
   ?token:Fpath.t ->
-  name:string option ->
   pkg_names:string list ->
   version:string option ->
   tag:string option ->

--- a/bin/tag.ml
+++ b/bin/tag.ml
@@ -70,10 +70,10 @@ let vcs_tag pkg tag ~dry_run ~commit_ish ~force ~sign ~delete ~msg ~yes =
           m "Tagged %a with version %a" Text.Pp.commit commit_ish
             Text.Pp.version tag)
 
-let tag () (`Dry_run dry_run) (`Dist_name name) (`Change_log change_log)
-    (`Version tag) (`Commit_ish commit_ish) (`Force force) (`Sign sign)
-    (`Delete delete) (`Msg msg) (`Yes yes) =
-  (let pkg = Pkg.v ~dry_run ?change_log ?name () in
+let tag () (`Dry_run dry_run) (`Change_log change_log) (`Version tag)
+    (`Commit_ish commit_ish) (`Force force) (`Sign sign) (`Delete delete)
+    (`Msg msg) (`Yes yes) =
+  (let pkg = Pkg.v ~dry_run ?change_log () in
    let tag =
      match tag with
      | Some t ->
@@ -154,8 +154,8 @@ let man =
 
 let cmd =
   ( Term.(
-      pure tag $ Cli.setup $ Cli.dry_run $ Cli.dist_name $ Cli.change_log
-      $ version $ commit $ force $ sign $ delete $ msg $ Cli.yes),
+      pure tag $ Cli.setup $ Cli.dry_run $ Cli.change_log $ version $ commit
+      $ force $ sign $ delete $ msg $ Cli.yes),
     Term.info "tag" ~doc ~sdocs ~exits ~man ~man_xrefs )
 
 (*---------------------------------------------------------------------------

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -434,8 +434,8 @@ let infer_name dir =
           | None ->
               Logs.err (fun m ->
                   m
-                    "cannot determine name automatically: use `--name <name>` \
-                     or add (name <name>) to dune-project");
+                    "cannot determine distribution name automatically: add \
+                     (name <name>) to dune-project");
               exit 1 ) )
 
 let v ~dry_run ?name ?version ?tag ?(keep_v = false) ?delegate ?build_dir

--- a/tests/bin/include-versioned-dotfiles/run.t
+++ b/tests/bin/include-versioned-dotfiles/run.t
@@ -16,6 +16,8 @@ We need a basic opam project skeleton
     > EOF
     $ cat > .gitignore << EOF \
     > _build\
+    > .formatted\
+    > dune\
     > run.t*\
     > EOF
 

--- a/tests/bin/tag-2-packages/run.t
+++ b/tests/bin/tag-2-packages/run.t
@@ -20,23 +20,8 @@ Set up a project with two packaged libraries, no name in dune-project.
 Check error message about name in dune-project.
 
     $ dune-release tag -y
-    dune-release: [ERROR] cannot determine name automatically: use `--name <name>` or add (name <name>) to dune-project
+    dune-release: [ERROR] cannot determine distribution name automatically: add (name <name>) to dune-project
     [1]
-
-Use --name to set name.
-
-    $ cat > CHANGES.md << EOF \
-    > ## 0.43.0\
-    > \
-    > - Some other feature\
-    > \
-    > EOF
-    $ git add CHANGES.md && git commit -m '0.43' > /dev/null
-
-    $ dune-release tag -y --name toto
-    [-] Extracting tag from first entry in CHANGES.md
-    [-] Using tag "0.43.0"
-    [+] Tagged HEAD with version 0.43.0
 
 Use (name <name>) in dune-project (not committed).
 


### PR DESCRIPTION
This removes option --name from all commands.

This fixes #324, where `dune-release distrib` would fail if a name is not present in `dune-project` (because it calls `dune subst`), therefore rendering pointless any passed --name.

So this pull request takes the brute force approach and removes --name from all commands. The upside is that this is simple, consistent and mostly removes code.

The downsides are:

- it causes a possible regression if people were using --name from other commands than `distrib` (I have no idea if that was useful or actually used ; I believe that for people with only one .opam file there would not have been a reason to use this)

- it removes the documentation for how the distribution is named (longest common prefix of .opam files, first word of main README title) : I'm not sure where to put it or even if it matters at all