### PR TITLE
Fix rewriting of github references (#yyy) in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@
 - Always warn about uncommitted changes at the start of `dune-release
   distrib` (#325, @lehy).  Otherwise uncommitted changes to
   dune-project would be silently ignored by `dune-release distrib`.
+- Fix rewriting of github references in changelog (#330, @gpetiot)
 
 ### Security
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -94,17 +94,6 @@ let pkg ~dry_run ~distrib_uri pkg =
       m "Wrote opam package description %a" Text.Pp.path dest_opam_file);
   if not dry_run then warn_if_vcs_dirty () else Ok ()
 
-let github_issue =
-  Re.(
-    compile
-    @@ seq [ group (compl [ alpha ]); group (seq [ char '#'; rep1 digit ]) ])
-
-let rewrite_github_refs user repo msg =
-  Re.replace github_issue msg ~f:(fun s ->
-      let x = Re.Group.get s 1 in
-      let y = Re.Group.get s 2 in
-      Fmt.strf "%s%s/%s%s" x user repo y)
-
 let rec pp_list pp ppf = function
   | [] -> ()
   | [ x ] -> pp ppf x
@@ -204,7 +193,7 @@ let submit ?distrib_uri ~token ~dry_run ~yes ~opam_repo ~user local_repo
         | Some user -> user (* trying to infer it from the remote repo URI *)
         | None -> distrib_user )
   in
-  let changes = rewrite_github_refs distrib_user repo changes in
+  let changes = Text.rewrite_github_refs ~user:distrib_user ~repo changes in
   let msg = strf "%s\n\n%s\n" title changes in
   App_log.status (fun l ->
       l "Preparing pull request to %a" pp_opam_repo opam_repo);

--- a/lib/text.ml
+++ b/lib/text.ml
@@ -128,6 +128,17 @@ let change_log_file_last_entry file =
   | None -> R.error_msgf "%a: Could not parse change log." Fpath.pp file
   | Some (version, (header, changes)) -> Ok (version, (header, changes))
 
+let github_issue =
+  Re.(
+    compile
+    @@ seq [ group (compl [ alnum ]); group (seq [ char '#'; rep1 digit ]) ])
+
+let rewrite_github_refs ~user ~repo msg =
+  Re.replace github_issue msg ~f:(fun s ->
+      let x = Re.Group.get s 1 in
+      let y = Re.Group.get s 2 in
+      Fmt.strf "%s%s/%s%s" x user repo y)
+
 (* Toy URI parsing *)
 
 let split_uri ?(rel = false) uri =

--- a/lib/text.mli
+++ b/lib/text.mli
@@ -54,6 +54,10 @@ val change_log_file_last_entry :
 (** [change_log_file_last_entry file] tries to parse the last change log entry
     of the file [file] using {!flavour_of_fpath} and {!change_log_last_entry}. *)
 
+val rewrite_github_refs : user:string -> repo:string -> string -> string
+(** [rewrite_github_refs ~user ~repo s] replaces references like [#yyy] with
+    [user/repo#yyy]. *)
+
 (** {1 Toy URI parsing} *)
 
 val split_uri : ?rel:bool -> string -> (string * string * string) option

--- a/tests/lib/test_text.ml
+++ b/tests/lib/test_text.ml
@@ -47,4 +47,24 @@ change B
       ~expected:(Some ("v0.1", ("# v0.1", "change A")));
   ]
 
-let suite = ("Text", test_change_log_last_entry)
+let test_rewrite_github_refs =
+  let user = "user" and repo = "repo" in
+  let make_test name (input, expected) =
+    let name = "rewrite_github_refs " ^ name in
+    let test_fun () =
+      Alcotest.(check string)
+        name expected
+        (Dune_release.Text.rewrite_github_refs ~user ~repo input)
+    in
+    (name, `Quick, test_fun)
+  in
+  [
+    make_test "rewritten 0" ("... #123 ...", "... user/repo#123 ...");
+    make_test "rewritten 1" ("... (#123 ...", "... (user/repo#123 ...");
+    make_test "not rewritten 0" ("... xyz#123 ...", "... xyz#123 ...");
+    make_test "not rewritten 1" ("... (xyz#123 ...", "... (xyz#123 ...");
+    make_test "not rewritten 2" ("... xy0#123 ...", "... xy0#123 ...");
+    make_test "not rewritten 3" ("... (xy0#123 ...", "... (xy0#123 ...");
+  ]
+
+let suite = ("Text", test_change_log_last_entry @ test_rewrite_github_refs)


### PR DESCRIPTION
Fix #313 