### PR TITLE
Support 'git://' scheme for dev-repo uri

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Allow including git submodules to the distrib tarball by passing the
   `--include-submodules` flag to `dune-release`, `dune-release bistro` or
   `dune-release distrib` (#300, @NathanReb)
+- Support 'git://' scheme for dev-repo uri (#331, @gpetiot)
 
 ### Changed
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -33,6 +33,8 @@ module Parse = struct
     match uri with
     | _ when Bos_setup.String.is_prefix uri ~affix:"git@" ->
         user_from_regexp_opt uri "git@github\\.com:\\(.+\\)/.+\\(\\.git\\)?"
+    | _ when Bos_setup.String.is_prefix uri ~affix:"git://" ->
+        user_from_regexp_opt uri "git://github\\.com/\\(.+\\)/.+\\(\\.git\\)?"
     | _ when Bos_setup.String.is_prefix uri ~affix:"https://" ->
         user_from_regexp_opt uri "https://github\\.com/\\(.+\\)/.+\\(\\.git\\)?"
     | _ -> None
@@ -48,6 +50,8 @@ module Parse = struct
     match uri with
     | _ when Bos_setup.String.is_prefix uri ~affix:"git@" ->
         path_from_regexp_opt uri "git@github\\.com:\\(.+\\)"
+    | _ when Bos_setup.String.is_prefix uri ~affix:"git://" ->
+        path_from_regexp_opt uri "git://github\\.com/\\(.+\\)"
     | _ when Bos_setup.String.is_prefix uri ~affix:"https://" ->
         path_from_regexp_opt uri "https://github\\.com/\\(.+\\)"
     | _ -> None

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -20,6 +20,8 @@ let test_user_from_remote =
     make_test "git@github.com:123/repo" (Some "123");
     make_test "wrong" None;
     make_test "https://github.com/username/repo.git" (Some "username");
+    make_test "git://github.com/user/repo.git" (Some "user");
+    make_test "git+https://github.com/user/repo.git" None;
   ]
 
 let test_ssh_uri_from_http =
@@ -39,6 +41,8 @@ let test_ssh_uri_from_http =
        otherwise *)
     check "https://not-github.com/dune-release" None;
     check "git@not-github.com:dune-release" None;
+    check "git://github.com/user/repo.git" (Some "git@github.com:user/repo.git");
+    check "git+https://github.com/user/repo.git" None;
   ]
 
 let suite = ("Github", test_user_from_remote @ test_ssh_uri_from_http)


### PR DESCRIPTION
Fix #312 
This is a temporary solution before something like #215 gets merged.