### PR TITLE
Make the automatic dune-release workflow to stop if a step exits with a non-zero code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
   This change allows users to push the tag manually to avoid using that code. (#219, @Julow)
 - Recursively exclude all `.git`/`.hg` files and folders from the distrib
   tarball (#300, @NathanReb)
+- Make the automatic dune-release workflow to stop if a step exits with a non-zero code (#332, @gpetiot)
 
 ### Deprecated
 


### PR DESCRIPTION
I think it's better to return the intermediate non-zero result as soon as it happens so we can have a more precise log, instead of just carrying on and ignoring the returned exit code of each step except the last one like it's currently the case, what do you think?

Actually some of dune-release steps could return unit instead of a return code but we can keep it like this for now in case we need these exit codes in the future. But personally I would replace these by unit, and use a sum/variant type instead.