### PR TITLE
Make git related tests more robust

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Recursively exclude all `.git`/`.hg` files and folders from the distrib
   tarball (#300, @NathanReb)
 - Make the automatic dune-release workflow to stop if a step exits with a non-zero code (#332, @gpetiot)
+- Make git-related mdx tests more robust in unusual environments (#334, @sternenseemann)
 
 ### Deprecated
 

--- a/tests/bin/delegate_info/run.t
+++ b/tests/bin/delegate_info/run.t
@@ -17,7 +17,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/distrib-name/run.t
+++ b/tests/bin/distrib-name/run.t
@@ -26,7 +26,9 @@ should set a name.
     > /dune\
     > run.t\
     > EOF
-    $ git init . > /dev/null
+    $ git init 2> /dev/null . > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add liba/* libb*/ CHANGES.md README LICENSE *.opam dune-project .gitignore
     $ git commit -m 'Commit.' > /dev/null
 

--- a/tests/bin/errors/run.t
+++ b/tests/bin/errors/run.t
@@ -17,7 +17,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project
     $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/include-submodules/run.t
+++ b/tests/bin/include-submodules/run.t
@@ -21,7 +21,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/include-versioned-dotfiles/run.t
+++ b/tests/bin/include-versioned-dotfiles/run.t
@@ -28,7 +28,9 @@ We also need a dotfile that we will properly version
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project .somedotfile .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/invalid-version-number/run.t
+++ b/tests/bin/invalid-version-number/run.t
@@ -31,7 +31,9 @@ We need to set up a git project for dune-release to work properly
     > /dune\
     > run.t\
     > EOF
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/no_doc/run.t
+++ b/tests/bin/no_doc/run.t
@@ -32,7 +32,9 @@ We need a basic opam project skeleton with an empty doc field
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam whatever-lib.opam dune-project README LICENSE
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -31,7 +31,9 @@ We need to set up a git project for dune-release to work properly
     > /dune\
     > run.t\
     > EOF
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -31,7 +31,9 @@ We need to set up a git project for dune-release to work properly
     > /dune\
     > run.t\
     > EOF
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/opam-pkg-distrib-file-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-file-opt/run.t
@@ -19,7 +19,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project
     $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/opam-pkg-distrib-uri-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-uri-opt/run.t
@@ -19,7 +19,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project for dune-release to work properly
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project
     $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/tag-2-packages/run.t
+++ b/tests/bin/tag-2-packages/run.t
@@ -13,7 +13,9 @@ Set up a project with two packaged libraries, no name in dune-project.
     $ echo "(library (public_name libb))" > libb/dune
     $ touch liba.opam libb.opam
     $ echo "(lang dune 2.7)" > dune-project
-    $ git init . > /dev/null
+    $ git init 2> /dev/null . > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add liba/* libb*/ CHANGES.md *.opam dune-project
     $ git commit -m 'Commit.' > /dev/null
 

--- a/tests/bin/tag/run.t
+++ b/tests/bin/tag/run.t
@@ -17,7 +17,9 @@ We need a basic opam project skeleton
 
 We need to set up a git project with two commits to test trying to tag different commits with the same tag name.
 
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add whatever.opam dune-project
     $ git commit -m "Initial commit" > /dev/null
     $ git add CHANGES.md

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -31,7 +31,9 @@ We need to set up a git project for dune-release to work properly
     > /dune\
     > run.t\
     > EOF
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y

--- a/tests/bin/x-commit-hash/run.t
+++ b/tests/bin/x-commit-hash/run.t
@@ -32,7 +32,9 @@ We need to set up a git project for dune-release to work properly
     > /dune\
     > run.t\
     > EOF
-    $ git init > /dev/null
+    $ git init 2> /dev/null > /dev/null
+    $ git config user.name "dune-release-test"
+    $ git config user.email "pseudo@pseudo.invalid"
     $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y


### PR DESCRIPTION
* ~~When running git init we pass -b main to set an initial branch
  explicitly. This prevents the hint informing you that git is
  defaulting to master from being printed when using more recent git
  versions.~~
* When running git init we also redirect stderr to /dev/null as
  newer versions of git print a hint to stderr if there's no default
  main branch name set and it is defaulting to 'master'. An alternative
  would be to pass -b, but that is not supported by older git versions
  as seen on debian, for example.
* after git init we set user.name and user.email for the repository, so
  the tests don't fail if they are executed in an environment without a
  global git config (CI, sandboxed build systems, …)