### PR TITLE
Fix release names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@
   dune-project would be silently ignored by `dune-release distrib`.
 - Fix rewriting of github references in changelog (#330, @gpetiot)
 - Fixes a bug under cygwin where dune-release was unable to find the commit hash corresponding to the release tag (#329, @gpetiot)
+- Fixes release names by explicitly setting it to match the released version (#338, @NathanReb)
 
 ### Security
 

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -5,7 +5,12 @@ type t = { url : string; args : Curl_option.t list }
 let create_release ~version ~msg ~user ~repo =
   let json : string =
     Yojson.Basic.to_string
-      (`Assoc [ ("tag_name", `String version); ("body", `String msg) ])
+      (`Assoc
+        [
+          ("tag_name", `String version);
+          ("name", `String version);
+          ("body", `String msg);
+        ])
   in
   let url = strf "https://api.github.com/repos/%s/%s/releases" user repo in
   let args =

--- a/lib/curl.ml
+++ b/lib/curl.ml
@@ -2,47 +2,10 @@ open Bos_setup
 
 type t = { url : string; args : Curl_option.t list }
 
-let escape_for_json s =
-  let len = String.length s in
-  let max = len - 1 in
-  let rec escaped_len i l =
-    if i > max then l
-    else
-      match s.[i] with
-      | '\\' | '\"' | '\n' | '\r' | '\t' -> escaped_len (i + 1) (l + 2)
-      | _ -> escaped_len (i + 1) (l + 1)
-  in
-  let escaped_len = escaped_len 0 0 in
-  if escaped_len = len then s
-  else
-    let b = Bytes.create escaped_len in
-    let rec loop i k =
-      if i > max then Bytes.unsafe_to_string b
-      else
-        match s.[i] with
-        | ('\\' | '\"' | '\n' | '\r' | '\t') as c ->
-            Bytes.set b k '\\';
-            let c =
-              match c with
-              | '\\' -> '\\'
-              | '\"' -> '\"'
-              | '\n' -> 'n'
-              | '\r' -> 'r'
-              | '\t' -> 't'
-              | _ -> assert false
-            in
-            Bytes.set b (k + 1) c;
-            loop (i + 1) (k + 2)
-        | c ->
-            Bytes.set b k c;
-            loop (i + 1) (k + 1)
-    in
-    loop 0 0
-
 let create_release ~version ~msg ~user ~repo =
-  let json =
-    strf "{ \"tag_name\" : \"%s\", \"body\" : \"%s\" }"
-      (escape_for_json version) (escape_for_json msg)
+  let json : string =
+    Yojson.Basic.to_string
+      (`Assoc [ ("tag_name", `String version); ("body", `String msg) ])
   in
   let url = strf "https://api.github.com/repos/%s/%s/releases" user repo in
   let args =
@@ -81,8 +44,14 @@ let open_pr ~title ~user ~branch ~body ~opam_repo =
   let base, repo = opam_repo in
   let url = strf "https://api.github.com/repos/%s/%s/pulls" base repo in
   let json =
-    strf {|{"title": %S,"base": "master", "body": %S, "head": "%s:%s"}|} title
-      body user branch
+    Yojson.Basic.to_string
+      (`Assoc
+        [
+          ("title", `String title);
+          ("base", `String "master");
+          ("body", `String body);
+          ("head", `String (strf "%s:%s" user branch));
+        ])
   in
   let args =
     let open Curl_option in

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -110,7 +110,7 @@ We make a dry-run release:
     [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API
     -: exec: curl --user foo:${token} --location --silent --show-error --config -
          --dump-header - --data
-         { "tag_name" : "0.1.0", "body" : "CHANGES:\n\n- Some other feature\n" }
+         {"tag_name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n"}
     [+] Succesfully created release with id 1
     [?] Upload _build/whatever-0.1.0.tbz as release asset? [Y/n]
     [-] Uploading _build/whatever-0.1.0.tbz as a release asset for 0.1.0 via github's API

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -110,7 +110,7 @@ We make a dry-run release:
     [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API
     -: exec: curl --user foo:${token} --location --silent --show-error --config -
          --dump-header - --data
-         {"tag_name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n"}
+         {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n"}
     [+] Succesfully created release with id 1
     [?] Upload _build/whatever-0.1.0.tbz as release asset? [Y/n]
     [-] Uploading _build/whatever-0.1.0.tbz as a release asset for 0.1.0 via github's API

--- a/tests/lib/test_curl.ml
+++ b/tests/lib/test_curl.ml
@@ -19,7 +19,9 @@ let test_create_release =
               Show_error;
               Config `Stdin;
               Dump_header `Ignore;
-              Data (`Data {|{"tag_name":"1.1.0","body":"this is a message"}|});
+              Data
+                (`Data
+                  {|{"tag_name":"1.1.0","name":"1.1.0","body":"this is a message"}|});
             ];
         };
   ]

--- a/tests/lib/test_curl.ml
+++ b/tests/lib/test_curl.ml
@@ -19,9 +19,7 @@ let test_create_release =
               Show_error;
               Config `Stdin;
               Dump_header `Ignore;
-              Data
-                (`Data
-                  {|{ "tag_name" : "1.1.0", "body" : "this is a message" }|});
+              Data (`Data {|{"tag_name":"1.1.0","body":"this is a message"}|});
             ];
         };
   ]
@@ -83,7 +81,7 @@ let test_open_pr =
               Dump_header `Ignore;
               Data
                 (`Data
-                  {|{"title": "This is a PR","base": "master", "body": "This PR fixes everything.\nThis is the best PR.\n", "head": "you:my-best-pr"}|});
+                  {|{"title":"This is a PR","base":"master","body":"This PR fixes everything.\nThis is the best PR.\n","head":"you:my-best-pr"}|});
             ];
         };
   ]


### PR DESCRIPTION
Fixes #337 

We used to rely on github's default name but it appears it changed recently. Setting this explicitly seems like the right thing to do.

@gpetiot you'll probably have to rebase #271 on top of this, in particular `tag_name` and `name` will obviously have different values, `name` being the actual version while `tag_name`will need to be sanitized in the same way the tag is!