### PR TITLE
Fix the process of inferring user name and repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 - Fixes a bug under cygwin where dune-release was unable to find the commit hash corresponding to the release tag (#329, @gpetiot)
 - Fixes release names by explicitly setting it to match the released version (#338, @NathanReb)
 - Fix a bug that prevented release of a package whose version number contains invalid characters for a git branch. The git branch names are now sanitized. (#271, @gpetiot)
+- `publish`: Fix the process of inferring user name and repo from the dev repo uri (#348, @pitag-ha)
 
 ### Security
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -181,10 +181,8 @@ let submit ?distrib_uri ~token ~dry_run ~yes ~opam_repo ~user local_repo
   list_map Pkg.name pkgs >>= fun names ->
   let title = strf "[new release] %a (%s)" (pp_list Fmt.string) names version in
   Pkg.publish_msg pkg >>= fun changes ->
-  (match distrib_uri with
-  | Some uri -> Ok uri
-  | None -> Pkg.infer_distrib_uri pkg)
-  >>= Pkg.distrib_user_and_repo
+  (match distrib_uri with Some uri -> Ok uri | None -> Pkg.infer_repo_uri pkg)
+  >>= Pkg.user_and_repo_from_uri
   >>= fun (distrib_user, repo) ->
   let user =
     match user with

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -94,7 +94,7 @@ let create_config ~user ~remote_repo ~local_repo pkgs file =
   | Some u -> Ok u
   | None ->
       let pkg = List.hd pkgs in
-      Pkg.infer_distrib_uri pkg >>= Pkg.distrib_user_and_repo >>= fun (u, _) ->
+      Pkg.infer_repo_uri pkg >>= Pkg.user_and_repo_from_uri >>= fun (u, _) ->
       Ok u)
   >>= fun default_user ->
   let user = read_string default_user ~descr:"What is your GitHub ID?" in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -358,11 +358,9 @@ let create_release ~dry_run ~yes ~dev_repo ~token ~msg ~tag ~version ~user ~repo
       Ok id
 
 let publish_distrib ?token ?distrib_uri ~dry_run ~msg ~archive ~yes p =
-  (match distrib_uri with
-  | Some uri -> Ok uri
-  | None -> Pkg.infer_distrib_uri p)
+  (match distrib_uri with Some uri -> Ok uri | None -> Pkg.infer_repo_uri p)
   >>= fun uri ->
-  (match Pkg.distrib_user_and_repo uri with
+  (match Pkg.user_and_repo_from_uri uri with
   | Error _ as e -> if dry_run then Ok (D.user, D.repo) else e
   | r -> r)
   >>= fun (user, repo) ->

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -105,7 +105,7 @@ let lint_opam_home_and_dev pkg =
     ~msgf:(fun l ->
       l "opam fields %a and %a can be parsed by dune-release" pp_field
         "homepage" pp_field "dev-repo")
-    (Pkg.infer_distrib_uri pkg >>= Pkg.distrib_user_and_repo)
+    (Pkg.infer_repo_uri pkg >>= Pkg.user_and_repo_from_uri)
 
 let lint_opam_github_fields pkg = lint_opam_doc pkg + lint_opam_home_and_dev pkg
 

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -83,6 +83,10 @@ val infer_distrib_uri : t -> (string, R.msg) result
 (** [infer_distrib_uri p] infers [p]'s distribution URI from the homepage and
     dev-repo fields. *)
 
+val infer_repo_uri : t -> (string, R.msg) result
+(** [infer_repo_uri p] infers [p]'s remote repository URI from the homepage and
+    dev-repo fields. *)
+
 val distrib_file : dry_run:bool -> t -> (Fpath.t, R.msg) result
 (** [distrib_file p] is [p]'s distribution archive. *)
 
@@ -119,7 +123,7 @@ val doc_dir : Fpath.t
 
 val doc_user_repo_and_path : t -> (string * string * Fpath.t, R.msg) result
 
-val distrib_user_and_repo : string -> (string * string, R.msg) result
+val user_and_repo_from_uri : string -> (string * string, R.msg) result
 
 type f =
   dry_run:bool ->

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -76,9 +76,12 @@ We do the whole dune-release process
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field description is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
+    dune-release: [ERROR] Could not derive user and repo from uri
+                          "https://whatever.io"; expected the pattern
+                          $SCHEME://$HOST/$USER/$REPO[.$EXT][/$DIR]
     [FAIL] opam field doc cannot be parsed by dune-release
-    [ OK ] lint _build/whatever-0.1.0 success
+    [FAIL] lint _build/whatever-0.1.0 failure: 1 errors.
     
     [-] Building package in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
@@ -89,11 +92,11 @@ We do the whole dune-release process
     => chdir _build/whatever-0.1.0
     -: exec: dune runtest -p whatever
     [ OK ] package tests
-    -: rmdir _build/whatever-0.1.0
     
     [+] Distribution for whatever 0.1.0
     [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
+    [1]
 
 (2) publish doc
 

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -76,9 +76,12 @@ We do the whole dune-release process
     -: exec: opam lint -s whatever.opam
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field description is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
+    dune-release: [ERROR] Could not derive user and repo from uri
+                          "https://whatever.io"; expected the pattern
+                          $SCHEME://$HOST/$USER/$REPO[.$EXT][/$DIR]
     [ OK ] Skipping doc field linting, no doc field found
-    [ OK ] lint _build/whatever-0.1.0 success
+    [FAIL] lint _build/whatever-0.1.0 failure: 1 errors.
     
     [-] Building package in _build/whatever-0.1.0
     => chdir _build/whatever-0.1.0
@@ -89,11 +92,11 @@ We do the whole dune-release process
     => chdir _build/whatever-0.1.0
     -: exec: dune runtest -p whatever
     [ OK ] package tests
-    -: rmdir _build/whatever-0.1.0
     
     [+] Distribution for whatever 0.1.0
     [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
+    [1]
 
 (2) publish distrib
 


### PR DESCRIPTION
This commit fixes the following two minor bugs in the workflow of inferring the user name and repo from the opam file fields `homepage` or `dev-repo`.

- It adds a test case for the case the user puts a local path or an empty string into the opam file fields. Before the commit, if the user did so, the first two directories of the corresponding absolute path got inferred as user and repo.

- Before this commit, the uri's in `homemapge` and `dev-repo` fields were transformed into the corresponding uri's to the distribution by appending "releases/download/{version}/{project name}-{version}.tbz" to them. From these distribution uri's, user name and repo were inferred. 
Example: if the uri in the opam file fields was "https://foo.com/", then the process of inferring user name and repo would not return an error, but infer "releases" and "downloads" as user and repo, respectively. With this commit user and repo get inferred directly from the uri's without first transforming them into the distribution uri's.