### PR TITLE
Fix make_check_deterministic dependency

### DIFF
--- a/tests/bin/check/dune
+++ b/tests/bin/check/dune
@@ -1,8 +1,6 @@
-(copy_files ../helpers/make_check_deterministic.exe)
-
 (alias
  (name runtest)
- (deps make_check_deterministic.exe))
+ (deps %{bin:make_check_deterministic.exe}))
 
 (mdx
  (files run.t)

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -27,7 +27,7 @@ Make a minimal project set up
 
 If the condition described above is fulfilled, there are 4 checks to be performed
 
-    $ dune-release check --working-tree | ./make_check_deterministic.exe
+    $ dune-release check --working-tree | make_check_deterministic.exe
     [-] Checking dune-release compatibility.
     [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
     [ OK ] The dune project contains a name stanza.
@@ -64,7 +64,7 @@ Add another package
 
 In multi package projects, the whole lint process (including the file lints, even though they are package independent) is done once for every package
 
-    $ dune-release check --working-tree | ./make_check_deterministic.exe
+    $ dune-release check --working-tree | make_check_deterministic.exe
     [-] Checking dune-release compatibility.
     [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
     [ OK ] The dune project contains a name stanza.
@@ -99,7 +99,7 @@ In multi package projects, the whole lint process (including the file lints, eve
 
 In the same way in which the user can skip the lint check when releasing the tarball, they can also skip it here
 
-    $ dune-release check --working-tree --skip-lint | ./make_check_deterministic.exe
+    $ dune-release check --working-tree --skip-lint | make_check_deterministic.exe
     [-] Checking dune-release compatibility.
     [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
     [ OK ] The dune project contains a name stanza.
@@ -112,7 +112,7 @@ In the same way in which the user can skip the lint check when releasing the tar
 
 Same for skipping the tests
 
-    $ dune-release check --working-tree --skip-lint --skip-test | ./make_check_deterministic.exe
+    $ dune-release check --working-tree --skip-lint --skip-test | make_check_deterministic.exe
     [-] Checking dune-release compatibility.
     [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
     [ OK ] The dune project contains a name stanza.

--- a/tests/bin/helpers/dune
+++ b/tests/bin/helpers/dune
@@ -1,3 +1,7 @@
 (executable
  (name make_check_deterministic)
  (libraries re))
+
+(install
+ (section bin)
+ (files make_check_deterministic.exe))


### PR DESCRIPTION
This tries to fix the dune issues I got locally since the `check` Pr got merged, when trying to execute `(copy_files ../helpers/make_check_deterministic.exe)` it reported this exe was not in the PATH or in the project.
But I'm not good enough with dune to be sure this fix is the right one and would be enough!

Here is the diff:
```diff
diff --git a/tests/bin/check/run.t b/tests/bin/check/.mdx/run.t.corrected
index 9a68470..9827e85 100644
--- a/tests/bin/check/run.t
+++ b/tests/bin/check/.mdx/run.t.corrected
@@ -33,10 +33,23 @@ If the condition described above is fulfilled, there are 4 checks to be performe
     [ OK ] The dune project contains a name stanza.
     
     [-] Building package in <test_directory>
-    [ OK ] package(s) build
+    Info: Appending this line to dune-project: (using mdx 0.1)
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) build
     
     [-] Running package tests in <test_directory>
-    [ OK ] package(s) pass the tests
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) pass the tests
     
     [-] Performing lint for package my_pkg in <test_directory>
     [FAIL] File README is missing.
@@ -70,10 +83,22 @@ In multi package projects, the whole lint process (including the file lints, eve
     [ OK ] The dune project contains a name stanza.
     
     [-] Building package in <test_directory>
-    [ OK ] package(s) build
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) build
     
     [-] Running package tests in <test_directory>
-    [ OK ] package(s) pass the tests
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) pass the tests
     
     [-] Performing lint for package my_pkg in <test_directory>
     [FAIL] File README is missing.
@@ -105,10 +130,22 @@ In the same way in which the user can skip the lint check when releasing the tar
     [ OK ] The dune project contains a name stanza.
     
     [-] Building package in <test_directory>
-    [ OK ] package(s) build
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) build
     
     [-] Running package tests in <test_directory>
-    [ OK ] package(s) pass the tests
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) pass the tests
 
 Same for skipping the tests
 
@@ -118,7 +155,13 @@ Same for skipping the tests
     [ OK ] The dune project contains a name stanza.
     
     [-] Building package in <test_directory>
-    [ OK ] package(s) build
+    File "dune", line 1, characters 12-51:
+    1 | (copy_files ../helpers/make_check_deterministic.exe)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Error: path outside the workspace: ../helpers/make_check_deterministic.exe
+    from .
+    
+    [FAIL] package(s) build
```