### PR TITLE
Fix opam submit for non gh projects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@
 
 ### Fixed
 
+- Fix a bug in `opam submit` preventing non-github users to create the opam-repo PR
+  via dune-release. (#359, @NathanReb)
 - Fix a bug where `opam submit` would try to parse the custom URI provided through
   `--distrib-uri` as a github repo URI instead of using the dev-repo (#358, @NathanReb)
 - Fix the priority of the `--distrib-uri` option in `dune-release opam pkg`.

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -244,13 +244,12 @@ let curl_upload_archive ~token ~dry_run ~yes archive user repo release_id =
       >>= fun url ->
       Github_v3_api.Archive.Response.name response >>= fun name -> Ok (url, name))
 
-let open_pr ~token ~dry_run ~title ~distrib_user ~user ~branch ~opam_repo ~draft
-    body pkg =
+let open_pr ~token ~dry_run ~title ~user ~branch ~opam_repo ~draft body pkg =
   let curl_t =
     Github_v3_api.Pull_request.Request.open_ ~title ~user ~branch ~body
       ~opam_repo ~draft
   in
-  github_v3_auth ~dry_run ~user:distrib_user token >>= fun auth ->
+  github_v3_auth ~dry_run ~user token >>= fun auth ->
   let curl_t = Github_v3_api.with_auth ~auth curl_t in
   let default_body = `Assoc [ ("html_url", `String D.pr_url) ] in
   run_with_auth ~dry_run ~default_body curl_t >>= fun json ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -60,7 +60,6 @@ val open_pr :
   token:Fpath.t ->
   dry_run:bool ->
   title:string ->
-  distrib_user:string ->
   user:string ->
   branch:Vcs.commit_ish ->
   opam_repo:string * string ->


### PR DESCRIPTION
Depends on #358

`dune-release opam submit` used to fail when releasing a package that wasn't hosted on github even though this is not required to go through this step.
One should be able to upload the distrib tarball to a custom place on the web and then still use dune-release to create the opam-repository PR as long as they provide the right informations on the command line.

This PR fixes this by skipping the github specific step that consists of rewriting the PR/issue references to the cross repo reference format in the PR message if neither of the `home` or `dev-repo` fields in the opam file points to github.

While working on this I also discovered there were some inconsistencies in the way the configuration is handled so I will fix them in a subsequent PR.