### PR TITLE
Fix opam submit

### DIFF
--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -16,7 +16,12 @@ val cmd : Cmd.t
 (** {1:publish Publish} *)
 
 val prepare_package :
-  dry_run:bool -> version:string -> Vcs.t -> string -> (unit, R.msg) result
+  build_dir:Fpath.t ->
+  dry_run:bool ->
+  version:string ->
+  Vcs.t ->
+  string ->
+  (unit, R.msg) result
 
 val prepare :
   dry_run:bool ->


### PR DESCRIPTION
We recently introduced a bug that completely broke the command as it wasn't able to properly locate the folder to add to opam-repo for the release.

This was introduced very recently so there's no need for a changelog entry!