### PR TITLE
Keep the first name encountered in dune-project.

### DIFF
--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -291,8 +291,8 @@ let dune_project_name dir =
       List.fold_left
         (fun acc line ->
           (* sorry *)
-          match String.cut ~sep:"(name " (String.trim line) with
-          | Some (_, s) ->
+          match (acc, String.cut ~sep:"(name " (String.trim line)) with
+          | None, Some (_, s) ->
               Some
                 (String.trim
                    ~drop:(function ')' | ' ' -> true | _ -> false)


### PR DESCRIPTION
When trying to infer the name from the `dune-project` file, we currently keep the last `(name ...)` encountered. However the root "name" stanza is usually around the beginning on the file, and it should probably take precedence on "package" stanza names.

I suppose we don't want to include a more advanced sexp parser to keep dependencies to a bare minimum.