### PR TITLE
Improve GH token management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,10 @@
 
 - Add `--local-repo`, `--remote-repo` and `--opam-repo` options to the default command,
   they used to be only available for the `opam` subcommand (#363, @NathanReb)
-- Add a `--token` option to `dune-release publish` and `dune-release opam` commands to specify a github token. This allows dune-release to be called through a Github Actions workflow and use the github token through an environment variable. (#284, @gpetiot)
+- Add a `--token` option to `dune-release publish` and `dune-release opam` commands
+  to specify a github token. This allows dune-release to be called through a Github
+  Actions workflow and use the github token through an environment variable.
+  (#284 #368, @gpetiot @NathanReb)
 - Log curl calls on verbose/debug mode (#281, @gpetiot)
 - Try to publish the release asset again after it failed (#272, @gpetiot)
 - Improve error reporting of failing git comands (#257, @gpetiot)
@@ -24,6 +27,9 @@
 
 ### Changed
 
+- Require tokens earlier in the execution of commands that use the github API. If the token
+  isn't saved to the user's configuration, the prompt for creating one will show up at the
+  command startup rather than on sending the first request (#368, @NathanReb)
 - Attach the changelog to the annotated tag message (#283, @gpetiot)
 - Do not remove versioned files from the tarball anymore. We used to exclude
   `.gitignore`, `.gitattributes` and other such files from the archive.
@@ -51,6 +57,8 @@
 
 ### Fixed
 
+- Fix a bug where subcommands wouldn't properly read the token files, leading to authentication
+  failures on API requests (#368, @NathanReb)
 - Fix a bug in `opam submit` preventing non-github users to create the opam-repo PR
   via dune-release. (#359, @NathanReb)
 - Fix a bug where `opam submit` would try to parse the custom URI provided through

--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -15,16 +15,17 @@ let bistro () (`Dry_run dry_run) (`Package_names pkg_names)
     (`Local_repo local_repo) (`Remote_repo remote_repo) (`Opam_repo opam_repo) =
   Cli.handle_error
     ( Dune_release.Config.keep_v keep_v >>= fun keep_v ->
+      Dune_release.Config.token ?cli_token:token ~dry_run () >>= fun token ->
       Distrib.distrib ~dry_run ~pkg_names ~version ~tag ~keep_v ~keep_dir:false
         ~skip_lint:false ~skip_build:false ~skip_tests:false ~include_submodules
         ()
       >! fun () ->
-      Publish.publish ?token ~pkg_names ~version ~tag ~keep_v ~dry_run
+      Publish.publish ~token ~pkg_names ~version ~tag ~keep_v ~dry_run
         ~publish_artefacts:[] ~yes:false ~draft ()
       >! fun () ->
       Opam.get_pkgs ~dry_run ~keep_v ~tag ~pkg_names ~version () >>= fun pkgs ->
       Opam.pkg ~dry_run ~pkgs () >! fun () ->
-      Opam.submit ?token ~dry_run ~pkgs ~pkg_names ~no_auto_open:false
+      Opam.submit ~token ~dry_run ~pkgs ~pkg_names ~no_auto_open:false
         ~yes:false ~draft () ?local_repo ?remote_repo ?opam_repo )
 
 (* Command line interface *)

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -64,11 +64,11 @@ let token =
      token for example as part of a Github Actions workflow where the github \
      token is provided through an environment variable."
   in
-  let docv = "FILE" in
+  let docv = "TOKEN" in
   let env = Arg.env_var "DUNE_RELEASE_GITHUB_TOKEN" in
   named
     (fun x -> `Token x)
-    Arg.(value & opt (some path_arg) None & info [ "token" ] ~doc ~docv ~env)
+    Arg.(value & opt (some string) None & info [ "token" ] ~doc ~docv ~env)
 
 let keep_v =
   let doc = "Do not drop the initial 'v' in the version string." in

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -56,7 +56,7 @@ val build_dir : [ `Build_dir of Fpath.t option ] Term.t
 val publish_msg : [ `Publish_msg of string option ] Term.t
 (** A [--msg] option to define a publication message. *)
 
-val token : [ `Token of Fpath.t option ] Term.t
+val token : [ `Token of string option ] Term.t
 (** A [--token] option to define the github token. *)
 
 val dry_run : [ `Dry_run of bool ] Term.t

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -283,6 +283,7 @@ let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
+  Config.token ?cli_token:token ~dry_run () >>= fun token ->
   Config.v ~user ~local_repo ~remote_repo pkgs >>= fun config ->
   (match local_repo with
   | Some r -> Ok Fpath.(v r)
@@ -299,8 +300,6 @@ let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
       | None -> R.error_msg "Unknown remote repository."))
   >>= fun remote_repo ->
   Config.auto_open (not no_auto_open) >>= fun auto_open ->
-  (match token with Some t -> Ok t | None -> Config.token ~dry_run ())
-  >>= fun token ->
   App_log.status (fun m ->
       m "Submitting %a" Fmt.(list ~sep:sp Text.Pp.name) pkg_names);
   submit ~token ~dry_run ~yes ~opam_repo ~user:config.user local_repo

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -45,7 +45,7 @@ val submit :
   ?remote_repo:string ->
   ?opam_repo:string * string ->
   ?user:string ->
-  ?token:Fpath.t ->
+  ?token:string ->
   dry_run:bool ->
   pkgs:Dune_release.Pkg.t list ->
   pkg_names:string list ->

--- a/bin/publish.mli
+++ b/bin/publish.mli
@@ -14,7 +14,7 @@ val publish :
   ?distrib_uri:string ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
-  ?token:Fpath.t ->
+  ?token:string ->
   pkg_names:string list ->
   version:string option ->
   tag:string option ->

--- a/bin/undraft.ml
+++ b/bin/undraft.ml
@@ -51,6 +51,7 @@ let undraft ?opam ?distrib_file ?opam_repo ?user ?token ?local_repo ?remote_repo
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
+  Config.token ?cli_token:token ~dry_run () >>= fun token ->
   Config.v ~user ~local_repo ~remote_repo [ pkg ] >>= fun config ->
   (match local_repo with
   | Some r -> Ok Fpath.(v r)
@@ -75,8 +76,6 @@ let undraft ?opam ?distrib_file ?opam_repo ?user ?token ?local_repo ?remote_repo
         | Some user -> user (* trying to infer it from the remote repo URI *)
         | None -> owner)
   in
-  (match token with Some t -> Ok t | None -> Config.token ~dry_run ())
-  >>= fun token ->
   Config.Draft_release.get ~dry_run ~build_dir ~name:pkg_name ~version
   >>= fun release_id ->
   App_log.status (fun l ->

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -29,7 +29,12 @@ val v :
   Pkg.t list ->
   (t, Bos_setup.R.msg) result
 
-val token : dry_run:bool -> unit -> (Fpath.t, Bos_setup.R.msg) result
+val token :
+  ?cli_token:string -> dry_run:bool -> unit -> (string, Bos_setup.R.msg) result
+(** Returns the token value that should be used for github API requests. If a
+    [cli_token] was provided, it is returned. Otherwise the token file in the
+    config dir is looked up. If it exists, its content is returned, if it does
+    not, the user is prompted for a token which will be then saved to that file. *)
 
 val keep_v : bool -> (bool, Bos_setup.R.msg) result
 

--- a/lib/delegate.ml
+++ b/lib/delegate.ml
@@ -22,7 +22,8 @@ let publish_distrib ?token ?distrib_uri ~dry_run ~msg ~archive ~yes ~draft pkg =
   Pkg.delegate pkg >>= function
   | None ->
       App_log.status (fun l -> l "Publishing to github");
-      Github.publish_distrib ?token ~dry_run ~yes ~msg ~archive ~draft pkg
+      Config.token ?cli_token:token ~dry_run () >>= fun token ->
+      Github.publish_distrib ~token ~dry_run ~yes ~msg ~archive ~draft pkg
       >>= fun url ->
       Pkg.archive_url_path pkg >>= fun url_file ->
       Sos.write_file ~dry_run url_file url >>= fun () -> Ok ()

--- a/lib/delegate.mli
+++ b/lib/delegate.mli
@@ -13,7 +13,7 @@ open Bos_setup
 (** {1 Publish} *)
 
 val publish_distrib :
-  ?token:Fpath.t ->
+  ?token:string ->
   ?distrib_uri:string ->
   dry_run:bool ->
   msg:string ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -26,7 +26,7 @@ end
 (** {1 Publish} *)
 
 val publish_distrib :
-  ?token:Fpath.t ->
+  token:string ->
   dry_run:bool ->
   msg:string ->
   archive:Fpath.t ->
@@ -46,7 +46,7 @@ val publish_doc :
   (unit, R.msg) Result.result
 
 val undraft_release :
-  token:Fpath.t ->
+  token:string ->
   dry_run:bool ->
   user:string ->
   repo:string ->
@@ -57,7 +57,7 @@ val undraft_release :
     release archive download URL. *)
 
 val open_pr :
-  token:Fpath.t ->
+  token:string ->
   dry_run:bool ->
   title:string ->
   user:string ->
@@ -69,7 +69,7 @@ val open_pr :
   ([ `Url of string | `Already_exists ], R.msg) result
 
 val undraft_pr :
-  token:Fpath.t ->
+  token:string ->
   dry_run:bool ->
   opam_repo:string * string ->
   pr_id:string ->

--- a/tests/bin/draft/run.t
+++ b/tests/bin/draft/run.t
@@ -54,7 +54,7 @@ We do the whole dune-release process
     [-] Publishing distribution
     => must exists _build/whatever-0.1.0.tbz
     [-] Publishing to github
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    ...
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     -: exec:
          git --git-dir .git ls-remote --quiet --tags   https://github.com/foo/whatever.git 0.1.0

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -105,7 +105,7 @@ We make a dry-run release:
     [-] Publishing distribution
     => must exists _build/whatever-0.1.0.tbz
     [-] Publishing to github
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    ...
     -: exec: git --git-dir .git rev-parse --verify 0.1.0
     ...
     [?] Create release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]


### PR DESCRIPTION
The CLI option and env var used to take path which made them unusable in a CI context. They now take the token value directly.

This also improves how the token is passed around, moving the config reading bits as close to the CLI entry points as possible so the rest of the code doesn't have to deal with this and simply require a mandatory token argument, with the value and not the path.

This finally fixes a bug where the content of token files wasn't always sanitized.