### PR TITLE
Use proper token based authentication for github v3 API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 ### Changed
 
+- Use pure token authentication for Github API requests rather than "token as passwords"
+  authentication (#369, @NathanReb)
 - Require tokens earlier in the execution of commands that use the github API. If the token
   isn't saved to the user's configuration, the prompt for creating one will show up at the
   command startup rather than on sending the first request (#368, @NathanReb)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -34,7 +34,9 @@ val token :
 (** Returns the token value that should be used for github API requests. If a
     [cli_token] was provided, it is returned. Otherwise the token file in the
     config dir is looked up. If it exists, its content is returned, if it does
-    not, the user is prompted for a token which will be then saved to that file. *)
+    not, the user is prompted for a token which will be then saved to that file.
+    When [dry_run] is [true] it always returns [Ok "${token}"] but still looks
+    up the relevant config file as it would normally have. *)
 
 val keep_v : bool -> (bool, Bos_setup.R.msg) result
 

--- a/lib/github_v3_api.ml
+++ b/lib/github_v3_api.ml
@@ -46,8 +46,11 @@ let handle_errors json ~try_ ~on_ok ~default_msg ~handled_errors =
                 documentation_url pp_errors errors
           | Error _ -> Error err))
 
-let with_auth ~auth Curl.{ url; meth; args } =
-  Curl.{ url; meth; args = Curl_option.User auth :: args }
+let with_auth ~token Curl.{ url; meth; args } =
+  let auth_header =
+    Curl_option.Header (Printf.sprintf "Authorization: token %s" token)
+  in
+  Curl.{ url; meth; args = auth_header :: args }
 
 module Release = struct
   module Request = struct

--- a/lib/github_v3_api.mli
+++ b/lib/github_v3_api.mli
@@ -1,6 +1,6 @@
 open Bos_setup
 
-val with_auth : auth:Curl_option.auth -> Curl.t -> Curl.t
+val with_auth : token:string -> Curl.t -> Curl.t
 
 module Release : sig
   module Request : sig

--- a/tests/bin/draft/run.t
+++ b/tests/bin/draft/run.t
@@ -64,15 +64,15 @@ We do the whole dune-release process
     ...
     [?] Create draft release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]
     [-] Creating draft release 0.1.0 on https://github.com/foo/whatever.git via github's API
-    -: exec: curl --user foo:${token} --location --silent --show-error --config -
-         --dump-header - --data
+    -: exec: curl --header Authorization: token ${token} --location --silent
+         --show-error --config - --dump-header - --data
          {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n","draft":true}
     [+] Successfully created draft release with id 1
     -: write _build/whatever-0.1.0.draft_release
     [?] Upload _build/whatever-0.1.0.tbz as release asset? [Y/n]
     [-] Uploading _build/whatever-0.1.0.tbz as a release asset for 0.1.0 via github's API
-    -: exec: curl --user foo:${token} --location --silent --show-error --config -
-         --dump-header - --header Content-Type:application/x-tar --data-binary
-         @_build/whatever-0.1.0.tbz
+    -: exec: curl --header Authorization: token ${token} --location --silent
+         --show-error --config - --dump-header - --header
+         Content-Type:application/x-tar --data-binary @_build/whatever-0.1.0.tbz
     -: write _build/whatever-0.1.0.release_asset_name
     -: write _build/whatever-0.1.0.url

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -110,15 +110,15 @@ We make a dry-run release:
     ...
     [?] Create release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API
-    -: exec: curl --user foo:${token} --location --silent --show-error --config -
-         --dump-header - --data
+    -: exec: curl --header Authorization: token ${token} --location --silent
+         --show-error --config - --dump-header - --data
          {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n","draft":false}
     [+] Successfully created release with id 1
     [?] Upload _build/whatever-0.1.0.tbz as release asset? [Y/n]
     [-] Uploading _build/whatever-0.1.0.tbz as a release asset for 0.1.0 via github's API
-    -: exec: curl --user foo:${token} --location --silent --show-error --config -
-         --dump-header - --header Content-Type:application/x-tar --data-binary
-         @_build/whatever-0.1.0.tbz
+    -: exec: curl --header Authorization: token ${token} --location --silent
+         --show-error --config - --dump-header - --header
+         Content-Type:application/x-tar --data-binary @_build/whatever-0.1.0.tbz
     -: write _build/whatever-0.1.0.url
 
 

--- a/tests/lib/test_github_v3_api.ml
+++ b/tests/lib/test_github_v3_api.ml
@@ -118,16 +118,15 @@ let test_open_pr =
   ]
 
 let test_with_auth =
-  let auth = Dune_release.Curl_option.{ user = "foo"; token = "bar" } in
-  let make_test ~test_name ~curl_t ~expected =
+  let make_test ~test_name ~token ~curl_t ~expected =
     let test_fun () =
-      let actual = with_auth ~auth curl_t in
+      let actual = with_auth ~token curl_t in
       Alcotest.check Alcotest_ext.curl test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in
   [
-    make_test ~test_name:"basic"
+    make_test ~test_name:"basic" ~token:"abc"
       ~curl_t:
         {
           url = "https://api.github.com/repos/base/repo/pulls";
@@ -138,7 +137,12 @@ let test_with_auth =
         {
           url = "https://api.github.com/repos/base/repo/pulls";
           meth = `POST;
-          args = [ User auth; Config `Stdin; Dump_header `Ignore ];
+          args =
+            [
+              Header "Authorization: token abc";
+              Config `Stdin;
+              Dump_header `Ignore;
+            ];
         };
   ]
 


### PR DESCRIPTION
This changes from using `-u user:token` to authenticate Github v3 API request to using the recommended `-H "Authorization: token <token>"`.

This allows for better interaction with some organization hosted repos and also allow us to drop the user config field which we won't need anymore!