### PR TITLE
Deprecate user options and config field and rely on remote-repo entirely

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@
 
 ### Changed
 
+- Entirely rely on the remote fork of opam-repository URL in `opam submit` instead of
+  reading the user separately. The information was redundant and could only lead to bugs
+  when unproperly set. (#372, @NathanReb)
 - Use pure token authentication for Github API requests rather than "token as passwords"
   authentication (#369, @NathanReb)
 - Require tokens earlier in the execution of commands that use the github API. If the token
@@ -50,6 +53,8 @@
 
 ### Deprecated
 
+- Deprecate the `--user` CLI options and configuration field, they were redundant with
+  the remote-repo option and field and could be set unproperly, leading to bugs (#372, @NathanReb)
 - Deprecate the use of delegates in `dune-release publish` (#276, #302, @pitag-ha)
 - Deprecate the use of opam file format 1.x (#352, @NathanReb)
 
@@ -62,6 +67,8 @@
 
 ### Fixed
 
+- Fix a bug where `opam submit` would fail on non-github repositories if the user had no
+  configuration file (#372, @NathanReb)
 - Fix a bug where subcommands wouldn't properly read the token files, leading to authentication
   failures on API requests (#368, @NathanReb)
 - Fix a bug in `opam submit` preventing non-github users to create the opam-repo PR

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -173,7 +173,8 @@ let include_submodules =
 
 let user =
   let doc =
-    "the name of the GitHub account where to push new opam-repository branches."
+    "the name of the GitHub account where to push new opam-repository \
+     branches. " ^ Deprecate.Config_user.option_doc
   in
   named
     (fun x -> `User x)

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -18,7 +18,9 @@ let show key =
       StdLabels.List.iter pretty_fields ~f:(fun (key, value) ->
           Logs.app (fun l -> l "%s: %s" key (show_val value)));
       Ok ()
-  | Some "user" -> log_val config.user
+  | Some "user" ->
+      Logs.warn (fun l -> l "%s" Deprecate.Config_user.config_field_use);
+      log_val config.user
   | Some "remote" -> log_val config.remote
   | Some "local" -> log_val (Stdext.Option.map ~f:Fpath.to_string config.local)
   | Some "keep-v" -> log_val (Stdext.Option.map ~f:string_of_bool config.keep_v)
@@ -37,7 +39,9 @@ let set key value =
   Config.load () >>= fun config ->
   let updated =
     match key with
-    | "user" -> Ok { config with user = Some value }
+    | "user" ->
+        App_log.unhappy (fun l -> l "%s" Deprecate.Config_user.config_field_use);
+        Ok { config with user = Some value }
     | "remote" -> Ok { config with remote = Some value }
     | "local" ->
         Fpath.of_string value >>| fun v -> { config with local = Some v }
@@ -96,8 +100,9 @@ let man =
       "Here are the existing fields of dune-release's global config file. Only \
        those values should be used as $(i,KEY):";
     `P
-      "$(b,user): The Github username of the opam-repository fork. Used to \
-       open the final PR to opam-repository.";
+      ("$(b,user): The Github username of the opam-repository fork. Used to \
+        open the final PR to opam-repository."
+     ^ Deprecate.Config_user.config_field_doc);
     `P
       "$(b,remote): The URL to your remote Github opam-repository fork. Used \
        to open the final PR to opam-repository.";

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -23,7 +23,6 @@ type t = {
 }
 
 val v :
-  user:string option ->
   remote_repo:string option ->
   local_repo:string option ->
   Pkg.t list ->

--- a/lib/deprecate.ml
+++ b/lib/deprecate.ml
@@ -38,3 +38,28 @@ module Opam_1_x = struct
 
   let remove_me : _ = Obj.magic ()
 end
+
+module Config_user = struct
+  let option_doc =
+    "This option is deprecated and will be removed in 2.0.0 as the user is \
+     redundant with the remote opam-repository fork from your configuration's \
+     $(b,remote) field or from the $(b,--remote-repo) option. Please use those \
+     instead."
+
+  let option_use =
+    "The --user option is deprecated and will be removed in 2.0.0 as the user \
+     is redundant with the remote opam-repository fork from your \
+     configuration's `remote` field or from the --remote-repo option. Please \
+     use those instead.\n\
+     Note that the user you provided will be ignored in favor of the above \
+     mentioned config field or command line option."
+
+  let config_field_doc =
+    "This configuration field is deprecated and will be removed in 2.0.0 as it \
+     is redundant with the $(b,remote) field. Its value will be ignored."
+
+  let config_field_use =
+    "The user configuration field is deprecated and will be removed in 2.0.0 \
+     as it is redundant with the remote field. Setting it to the wrong value \
+     can lead to bugs. Please use the remote field only."
+end

--- a/lib/deprecate.mli
+++ b/lib/deprecate.mli
@@ -35,3 +35,21 @@ module Opam_1_x : sig
   (** Dummy value used to flag part of the code we should remove when dropping
       support for opam 1.x *)
 end
+
+module Config_user : sig
+  val option_doc : string
+  (** Documentation bit indicating the --user option is deprecated because it is
+      redundant with the --remote-repo option. *)
+
+  val option_use : string
+  (** Message warning users they used the deprecated --user option and that they
+      should use --remote-repo only. *)
+
+  val config_field_doc : string
+  (** Documentation bit indicating the user configuration field is deprecated
+      because it is redundant with the remote field. *)
+
+  val config_field_use : string
+  (** Message warning users they are setting the deprecated user field of their
+      configuration. *)
+end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -27,20 +27,6 @@ module D = struct
 end
 
 module Parse = struct
-  let user_from_regexp_opt uri regexp =
-    try Some Re.(Group.get (exec (Emacs.compile_pat regexp) uri) 1)
-    with Not_found -> None
-
-  let user_from_remote uri =
-    match uri with
-    | _ when Bos_setup.String.is_prefix uri ~affix:"git@" ->
-        user_from_regexp_opt uri "git@github\\.com:\\(.+\\)/.+\\(\\.git\\)?"
-    | _ when Bos_setup.String.is_prefix uri ~affix:"git://" ->
-        user_from_regexp_opt uri "git://github\\.com/\\(.+\\)/.+\\(\\.git\\)?"
-    | _ when Bos_setup.String.is_prefix uri ~affix:"https://" ->
-        user_from_regexp_opt uri "https://github\\.com/\\(.+\\)/.+\\(\\.git\\)?"
-    | _ -> None
-
   let path_from_regexp_opt uri regexp =
     try
       Some

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -233,9 +233,10 @@ let curl_upload_archive ~token ~dry_run ~yes archive user repo release_id =
       >>= fun url ->
       Github_v3_api.Archive.Response.name response >>= fun name -> Ok (url, name))
 
-let open_pr ~token ~dry_run ~title ~user ~branch ~opam_repo ~draft body pkg =
+let open_pr ~token ~dry_run ~title ~fork_owner ~branch ~opam_repo ~draft body
+    pkg =
   let curl_t =
-    Github_v3_api.Pull_request.Request.open_ ~title ~user ~branch ~body
+    Github_v3_api.Pull_request.Request.open_ ~title ~fork_owner ~branch ~body
       ~opam_repo ~draft
   in
   let curl_t = Github_v3_api.with_auth ~token curl_t in
@@ -251,12 +252,12 @@ let open_pr ~token ~dry_run ~title ~user ~branch ~opam_repo ~draft body pkg =
   else Ok ())
   >>= fun () -> Github_v3_api.Pull_request.Response.html_url json
 
-let undraft_release ~token ~dry_run ~user ~repo ~release_id ~name =
+let undraft_release ~token ~dry_run ~owner ~repo ~release_id ~name =
   (match int_of_string_opt release_id with
   | Some id -> Ok id
   | None -> R.error_msgf "Invalid Github Release id: %s" release_id)
   >>= fun release_id ->
-  let curl_t = Github_v3_api.Release.Request.undraft ~user ~repo ~release_id in
+  let curl_t = Github_v3_api.Release.Request.undraft ~owner ~repo ~release_id in
   let default_body =
     `Assoc [ ("browser_download_url", `String D.download_url) ]
   in

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -9,16 +9,6 @@
 open Bos_setup
 
 module Parse : sig
-  val user_from_remote : string -> string option
-  (** [user_from_remote remote_uri] is the username in the github URI
-      [remote_uri], ie:
-
-      - [user_from_remote_uri "git@github.com:username/repo.git"] returns
-        [Some "username"]
-      - [user_from_remote_uri "https://github.com/username/repo.git"] returns
-        [Some "username"].
-      - Returns [None] if [remote_uri] isn't in the expected format. *)
-
   val ssh_uri_from_http : string -> string option
   (** [ssh_uri_from_http] Guess an SSH URI from a Github HTTP url. *)
 end

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -48,7 +48,7 @@ val publish_doc :
 val undraft_release :
   token:string ->
   dry_run:bool ->
-  user:string ->
+  owner:string ->
   repo:string ->
   release_id:string ->
   name:string ->
@@ -60,7 +60,7 @@ val open_pr :
   token:string ->
   dry_run:bool ->
   title:string ->
-  user:string ->
+  fork_owner:string ->
   branch:Vcs.commit_ish ->
   opam_repo:string * string ->
   draft:bool ->

--- a/lib/github_v3_api.ml
+++ b/lib/github_v3_api.ml
@@ -90,10 +90,10 @@ module Release = struct
       in
       Curl.{ url; meth = `POST; args }
 
-    let undraft ~user ~repo ~release_id =
+    let undraft ~owner ~repo ~release_id =
       let json = Yojson.Basic.to_string (`Assoc [ ("draft", `Bool false) ]) in
       let url =
-        strf "https://api.github.com/repos/%s/%s/releases/%i" user repo
+        strf "https://api.github.com/repos/%s/%s/releases/%i" owner repo
           release_id
       in
       let args =
@@ -181,7 +181,7 @@ end
 
 module Pull_request = struct
   module Request = struct
-    let open_ ~title ~user ~branch ~body ~opam_repo ~draft =
+    let open_ ~title ~fork_owner ~branch ~body ~opam_repo ~draft =
       let base, repo = opam_repo in
       let url = strf "https://api.github.com/repos/%s/%s/pulls" base repo in
       let json =
@@ -191,7 +191,7 @@ module Pull_request = struct
               ("title", `String title);
               ("base", `String "master");
               ("body", `String body);
-              ("head", `String (strf "%s:%s" user branch));
+              ("head", `String (strf "%s:%s" fork_owner branch));
               ("draft", `Bool draft);
             ])
       in

--- a/lib/github_v3_api.mli
+++ b/lib/github_v3_api.mli
@@ -15,7 +15,7 @@ module Release : sig
       draft:bool ->
       Curl.t
 
-    val undraft : user:string -> repo:string -> release_id:int -> Curl.t
+    val undraft : owner:string -> repo:string -> release_id:int -> Curl.t
   end
 
   module Response : sig
@@ -52,7 +52,7 @@ module Pull_request : sig
   module Request : sig
     val open_ :
       title:string ->
-      user:string ->
+      fork_owner:string ->
       branch:string ->
       body:string ->
       opam_repo:string * string ->

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -2,15 +2,15 @@ type answer = Yes | No
 
 open Bos_setup.R.Infix
 
-let ask f ~default_answer =
+let ask_yes_no f ~default_answer =
   let options : ('a, Format.formatter, unit, unit) format4 =
     match default_answer with Yes -> " [Y/n]" | No -> " [y/N]"
   in
   App_log.question (fun l ->
       f (fun ?header ?tags fmt -> l ?header ?tags (fmt ^^ options)))
 
-let rec loop ~question ~default_answer =
-  ask question ~default_answer;
+let rec loop_yes_no ~question ~default_answer =
+  ask_yes_no question ~default_answer;
   match String.lowercase_ascii (read_line ()) with
   | "" when default_answer = Yes -> true
   | "" when default_answer = No -> false
@@ -21,10 +21,10 @@ let rec loop ~question ~default_answer =
           l
             "Please answer with \"y\" for yes, \"n\" for no or just hit enter \
              for the default");
-      loop ~question ~default_answer
+      loop_yes_no ~question ~default_answer
 
 let confirm ~question ~yes ~default_answer =
-  if yes then true else loop ~question ~default_answer
+  if yes then true else loop_yes_no ~question ~default_answer
 
 let confirm_or_abort ~question ~yes ~default_answer =
   if confirm ~question ~yes ~default_answer then Ok ()
@@ -38,3 +38,29 @@ let rec try_again ?(limit = 1) ~question ~yes ~default_answer f =
       confirm_or_abort ~yes ~question ~default_answer >>= fun () ->
       try_again ~limit:(limit - 1) ~question ~yes ~default_answer f
   | Error x -> Error x
+
+let ask ~question ~default_answer =
+  let pp_default fmt default =
+    match default with
+    | Some default ->
+        Fmt.pf fmt "[press ENTER to use '%a']" Fmt.(styled `Bold string) default
+    | None -> ()
+  in
+  App_log.question (fun l -> l "%s%a" question pp_default default_answer)
+
+let rec loop ~question ~default_answer =
+  ask ~question ~default_answer;
+  let answer =
+    match read_line () with
+    | "" -> None
+    | s -> Some s
+    | exception End_of_file -> None
+  in
+  match (answer, default_answer) with
+  | Some s, _ -> s
+  | None, Some default -> default
+  | None, None ->
+      App_log.unhappy (fun l -> l "dune-release needs an answer to proceed.");
+      loop ~question ~default_answer
+
+let user_input ?default_answer ~question () = loop ~question ~default_answer

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -29,3 +29,5 @@ val try_again :
     running [f] again if it failed, until [f] eventually succeeds or the user
     aborts the process by answering no or the maximum number of retries [limit]
     is reached (retries only once by default). *)
+
+val user_input : ?default_answer:string -> question:string -> unit -> string

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -1,29 +1,3 @@
-let test_user_from_remote =
-  let make_test repo_uri expected =
-    let test_name = "Parse.user_from_remote " ^ repo_uri in
-    let test_fun () =
-      Alcotest.(check (option string))
-        repo_uri expected
-        (Dune_release.Github.Parse.user_from_remote repo_uri)
-    in
-    (test_name, `Quick, test_fun)
-  in
-  [
-    make_test "git@github.com:username/repo.git" (Some "username");
-    make_test "git@github.com:user-name/repo.git" (Some "user-name");
-    make_test "git@github.com:user-name-123/repo.git" (Some "user-name-123");
-    make_test "git@github.com:123/repo.git" (Some "123");
-    (* Same as above but without the .git part *)
-    make_test "git@github.com:username/repo" (Some "username");
-    make_test "git@github.com:user-name/repo" (Some "user-name");
-    make_test "git@github.com:user-name-123/repo" (Some "user-name-123");
-    make_test "git@github.com:123/repo" (Some "123");
-    make_test "wrong" None;
-    make_test "https://github.com/username/repo.git" (Some "username");
-    make_test "git://github.com/user/repo.git" (Some "user");
-    make_test "git+https://github.com/user/repo.git" None;
-  ]
-
 let test_ssh_uri_from_http =
   let check inp expected =
     let test_name = "Parse.ssh_uri_from_http " ^ inp in
@@ -45,4 +19,4 @@ let test_ssh_uri_from_http =
     check "git+https://github.com/user/repo.git" None;
   ]
 
-let suite = ("Github", test_user_from_remote @ test_ssh_uri_from_http)
+let suite = ("Github", test_ssh_uri_from_http)

--- a/tests/lib/test_github_v3_api.ml
+++ b/tests/lib/test_github_v3_api.ml
@@ -74,11 +74,12 @@ let test_upload_archive =
   ]
 
 let test_open_pr =
-  let make_test ~test_name ~title ~user ~branch ~body ~opam_repo ~draft
+  let make_test ~test_name ~title ~fork_owner ~branch ~body ~opam_repo ~draft
       ~expected =
     let test_fun () =
       let actual =
-        Pull_request.Request.open_ ~title ~user ~branch ~body ~opam_repo ~draft
+        Pull_request.Request.open_ ~title ~fork_owner ~branch ~body ~opam_repo
+          ~draft
       in
       Alcotest.check Alcotest_ext.curl test_name expected actual
     in
@@ -86,12 +87,13 @@ let test_open_pr =
   in
   [
     (let title = "This is a PR"
-     and user = "you"
+     and fork_owner = "you"
      and branch = "my-best-pr"
      and body = "This PR fixes everything.\nThis is the best PR.\n"
      and opam_repo = ("base", "repo")
      and draft = false in
-     make_test ~test_name:"simple" ~title ~user ~branch ~body ~opam_repo ~draft
+     make_test ~test_name:"simple" ~title ~fork_owner ~branch ~body ~opam_repo
+       ~draft
        ~expected:
          {
            url = "https://api.github.com/repos/base/repo/pulls";
@@ -110,7 +112,9 @@ let test_open_pr =
                           ("title", `String title);
                           ("base", `String "master");
                           ("body", `String body);
-                          ("head", `String (Bos_setup.strf "%s:%s" user branch));
+                          ( "head",
+                            `String (Bos_setup.strf "%s:%s" fork_owner branch)
+                          );
                           ("draft", `Bool draft);
                         ])));
              ];
@@ -147,15 +151,15 @@ let test_with_auth =
   ]
 
 let test_undraft_release =
-  let make_test ~test_name ~user ~repo ~release_id ~expected =
+  let make_test ~test_name ~owner ~repo ~release_id ~expected =
     let test_fun () =
-      let actual = Release.Request.undraft ~user ~repo ~release_id in
+      let actual = Release.Request.undraft ~owner ~repo ~release_id in
       Alcotest.check Alcotest_ext.curl test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in
   [
-    make_test ~test_name:"basic" ~user:"user" ~repo:"some-repo" ~release_id:42
+    make_test ~test_name:"basic" ~owner:"user" ~repo:"some-repo" ~release_id:42
       ~expected:
         {
           url = "https://api.github.com/repos/user/some-repo/releases/42";


### PR DESCRIPTION
This PR deprecates the `user` CLI option and config field.

The value, whether it comes from the CLI or the config is ignored, we rely entirely on remote-repo now.
Deprecation warnings are emitted whenever someone tries to use the CLI option and if they try to read or modify the field via the `config` subcommand.

New configuration will be created without a user field from now on.

I fixed the config creation step as before it would crash if the repo wasn't hosted on github because it was trying to parse the opam files field, looking for a github username to use as a suggestion in the config creation quiz.

There are further things to fix here, in particular, the fact that we still try to create a config even if all the information is provided via the command line. I will take care of this in a subsequent PR.

I have to test this a bit so I'm marking as draft but feedback is welcome!