### PR TITLE
Fix interpretation of --local-repo and --remote-repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Add a `config create` subcommand to create a fresh configuration if you don't have one yet
+  (#???, @NathanReb)
 - Add `--local-repo`, `--remote-repo` and `--opam-repo` options to the default command,
   they used to be only available for the `opam` subcommand (#363, @NathanReb)
 - Add a `--token` option to `dune-release publish` and `dune-release opam` commands

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Add a `config create` subcommand to create a fresh configuration if you don't have one yet
-  (#???, @NathanReb)
+  (#373, @NathanReb)
 - Add `--local-repo`, `--remote-repo` and `--opam-repo` options to the default command,
   they used to be only available for the `opam` subcommand (#363, @NathanReb)
 - Add a `--token` option to `dune-release publish` and `dune-release opam` commands
@@ -69,6 +69,10 @@
 
 ### Fixed
 
+- Fix a bug where `opam submit` would look up a config file, even though all the required
+  information was provided on the command line. This would lead to starting the interactive
+  config creation quizz if that file did not exist which made it impossible to use it in a CI
+  for instance. (#373, @NathanReb)
 - Fix a bug where `opam submit` would fail on non-github repositories if the user had no
   configuration file (#372, @NathanReb)
 - Fix a bug where subcommands wouldn't properly read the token files, leading to authentication

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -14,6 +14,11 @@ open Dune_release
 
 let path_arg = Arg.conv Fpath.(of_string, pp)
 
+let dir_path_arg =
+  let dir_parse = Arg.(conv_parser dir) in
+  let parse s = dir_parse s >>= Fpath.of_string in
+  Arg.conv ~docv:"DIR" (parse, Fpath.pp)
+
 let named f = Cmdliner.Term.(app (const f))
 
 let dist_tag =
@@ -188,7 +193,7 @@ let local_repo =
     (fun x -> `Local_repo x)
     Arg.(
       value
-      & opt (some string) None
+      & opt (some dir_path_arg) None
       & info ~env [ "l"; "local-repo" ] ~doc ~docv:"PATH")
 
 let remote_repo =

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -75,7 +75,7 @@ val user : [ `User of string option ] Term.t
 (** A [--user] option to define the name of the GitHub account where to push new
     opam-repository branches. *)
 
-val local_repo : [ `Local_repo of string option ] Term.t
+val local_repo : [ `Local_repo of Fpath.t option ] Term.t
 (** A [--local-repo] option to define the location of the local fork of
     opam-repository. *)
 

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -5,28 +5,42 @@ let invalid_config_key key =
 
 let show_val = function None -> "<unset>" | Some x -> x
 
-let log_val string_opt =
+let log_val s =
+  Logs.app (fun l -> l "%s" s);
+  Ok ()
+
+let log_val_opt string_opt =
   Logs.app (fun l -> l "%s" (show_val string_opt));
   Ok ()
 
+let no_config_message =
+  "You don't have a dune-release config file yet. You can create one by \
+   running `dune-release config create` or simply wait for dune-release to \
+   prompt you when it will actually need it."
+
 let show key =
   let open Rresult.R.Infix in
-  Config.load () >>= fun config ->
-  match key with
+  Config.load () >>= function
   | None ->
-      let pretty_fields = Config.pretty_fields config in
-      StdLabels.List.iter pretty_fields ~f:(fun (key, value) ->
-          Logs.app (fun l -> l "%s: %s" key (show_val value)));
+      App_log.status (fun l -> l "%s" no_config_message);
       Ok ()
-  | Some "user" ->
-      Logs.warn (fun l -> l "%s" Deprecate.Config_user.config_field_use);
-      log_val config.user
-  | Some "remote" -> log_val config.remote
-  | Some "local" -> log_val (Stdext.Option.map ~f:Fpath.to_string config.local)
-  | Some "keep-v" -> log_val (Stdext.Option.map ~f:string_of_bool config.keep_v)
-  | Some "auto-open" ->
-      log_val (Stdext.Option.map ~f:string_of_bool config.auto_open)
-  | Some key -> invalid_config_key key
+  | Some config -> (
+      match key with
+      | None ->
+          let pretty_fields = Config.pretty_fields config in
+          StdLabels.List.iter pretty_fields ~f:(fun (key, value) ->
+              Logs.app (fun l -> l "%s: %s" key (show_val value)));
+          Ok ()
+      | Some "user" ->
+          Logs.warn (fun l -> l "%s" Deprecate.Config_user.config_field_use);
+          log_val_opt config.user
+      | Some "remote" -> log_val config.remote
+      | Some "local" -> log_val (Fpath.to_string config.local)
+      | Some "keep-v" ->
+          log_val_opt (Stdext.Option.map ~f:string_of_bool config.keep_v)
+      | Some "auto-open" ->
+          log_val_opt (Stdext.Option.map ~f:string_of_bool config.auto_open)
+      | Some key -> invalid_config_key key)
 
 let to_bool ~field value =
   match String.lowercase_ascii value with
@@ -36,22 +50,38 @@ let to_bool ~field value =
 
 let set key value =
   let open Rresult.R.Infix in
-  Config.load () >>= fun config ->
-  let updated =
-    match key with
-    | "user" ->
-        App_log.unhappy (fun l -> l "%s" Deprecate.Config_user.config_field_use);
-        Ok { config with user = Some value }
-    | "remote" -> Ok { config with remote = Some value }
-    | "local" ->
-        Fpath.of_string value >>| fun v -> { config with local = Some v }
-    | "keep-v" ->
-        to_bool ~field:key value >>| fun v -> { config with keep_v = Some v }
-    | "auto-open" ->
-        to_bool ~field:key value >>| fun v -> { config with auto_open = Some v }
-    | _ -> invalid_config_key key
-  in
-  updated >>= Config.save >>= fun () -> Ok ()
+  Config.load () >>= function
+  | None -> Rresult.R.error_msgf "%s" no_config_message
+  | Some config ->
+      let updated =
+        match key with
+        | "user" ->
+            App_log.unhappy (fun l ->
+                l "%s" Deprecate.Config_user.config_field_use);
+            Ok { config with user = Some value }
+        | "remote" -> Ok { config with remote = value }
+        | "local" ->
+            Fpath.of_string value >>| fun v -> { config with local = v }
+        | "keep-v" ->
+            to_bool ~field:key value >>| fun v ->
+            { config with keep_v = Some v }
+        | "auto-open" ->
+            to_bool ~field:key value >>| fun v ->
+            { config with auto_open = Some v }
+        | _ -> invalid_config_key key
+      in
+      updated >>= Config.save >>= fun () -> Ok ()
+
+let create () =
+  let open Rresult.R.Infix in
+  Config.load () >>= function
+  | None -> Config.create ()
+  | Some _ ->
+      App_log.status (fun l ->
+          l
+            "You already have a dune-release configuration file. Use \
+             `dune-release config set` to modify it.");
+      Ok ()
 
 let default_usage ?raw () =
   let cmd = "dune-release config" in
@@ -72,6 +102,10 @@ let set_usage ?raw () =
   | Some () -> Printf.sprintf "%s %s %s" cmd key value
   | None -> Printf.sprintf "$(b,%s) $(i,%s) $(i,%s)" cmd key value
 
+let create_usage ?raw () =
+  let cmd = "dune-release config create" in
+  match raw with Some () -> cmd | None -> Printf.sprintf "$(b,%s)" cmd
+
 let invalid_usage () =
   Rresult.R.error_msgf
     "Invalid dune-release config invocation. Usage:\n%s\n%s\n%s"
@@ -83,6 +117,7 @@ let run action key_opt value_opt =
      match (action, key_opt, value_opt) with
      | "show", key, None -> show key
      | "set", Some key, Some value -> set key value
+     | "create", None, None -> create ()
      | _ -> invalid_usage ()
    in
    res >>= fun () -> Ok 0)
@@ -95,6 +130,7 @@ let man =
     `P (default_usage ());
     `P (show_usage ());
     `P (set_usage ());
+    `P (create_usage ());
     `S "GLOBAL CONFIGURATION FIELDS";
     `P
       "Here are the existing fields of dune-release's global config file. Only \

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -296,7 +296,7 @@ let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
   Config.token ?cli_token:token ~dry_run () >>= fun token ->
   Config.v ~local_repo ~remote_repo pkgs >>= fun config ->
   (match local_repo with
-  | Some r -> Ok Fpath.(v r)
+  | Some r -> Ok r
   | None -> (
       match config.local with
       | Some r -> Ok r

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -295,20 +295,10 @@ let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
   report_user_option_use user;
   Config.token ?cli_token:token ~dry_run () >>= fun token ->
   Config.v ~local_repo ~remote_repo pkgs >>= fun config ->
-  (match local_repo with
-  | Some r -> Ok r
-  | None -> (
-      match config.local with
-      | Some r -> Ok r
-      | None -> R.error_msg "Unknown local repository."))
-  >>= fun local_repo ->
-  (match remote_repo with
-  | Some r -> Ok r
-  | None -> (
-      match config.remote with
-      | Some r -> Ok r
-      | None -> R.error_msg "Unknown remote repository."))
-  >>= fun remote_repo ->
+  let local_repo = match local_repo with Some r -> r | None -> config.local in
+  let remote_repo =
+    match remote_repo with Some r -> r | None -> config.remote
+  in
   Config.auto_open (not no_auto_open) >>= fun auto_open ->
   App_log.status (fun m ->
       m "Submitting %a" Fmt.(list ~sep:sp Text.Pp.name) pkg_names);

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -287,23 +287,18 @@ let report_user_option_use user =
   | None -> ()
   | Some _ -> App_log.unhappy (fun l -> l "%s" Deprecate.Config_user.option_use)
 
-let submit ?local_repo ?remote_repo ?opam_repo ?user ?token ~dry_run ~pkgs
-    ~pkg_names ~no_auto_open ~yes ~draft () =
+let submit ?local_repo:local ?remote_repo:remote ?opam_repo ?user ?token
+    ~dry_run ~pkgs ~pkg_names ~no_auto_open ~yes ~draft () =
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
   report_user_option_use user;
   Config.token ?cli_token:token ~dry_run () >>= fun token ->
-  Config.v ~local_repo ~remote_repo pkgs >>= fun config ->
-  let local_repo = match local_repo with Some r -> r | None -> config.local in
-  let remote_repo =
-    match remote_repo with Some r -> r | None -> config.remote
-  in
+  Config.opam_repo_fork ~pkgs ~local ~remote () >>= fun { remote; local } ->
   Config.auto_open (not no_auto_open) >>= fun auto_open ->
   App_log.status (fun m ->
       m "Submitting %a" Fmt.(list ~sep:sp Text.Pp.name) pkg_names);
-  submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
-    ~draft
+  submit ~token ~dry_run ~yes ~opam_repo local remote pkgs auto_open ~draft
 
 let field ~pkgs ~field_name = field pkgs field_name
 

--- a/bin/opam.mli
+++ b/bin/opam.mli
@@ -41,7 +41,7 @@ val pkg :
     for success, 1 for failure) or error messages. *)
 
 val submit :
-  ?local_repo:string ->
+  ?local_repo:Fpath.t ->
   ?remote_repo:string ->
   ?opam_repo:string * string ->
   ?user:string ->

--- a/bin/undraft.ml
+++ b/bin/undraft.ml
@@ -53,20 +53,10 @@ let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo ?remote_repo
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
-  (match local_repo with
-  | Some r -> Ok r
-  | None -> (
-      match config.local with
-      | Some r -> Ok r
-      | None -> R.error_msg "Unknown local repository."))
-  >>= fun local_repo ->
-  (match remote_repo with
-  | Some r -> Ok r
-  | None -> (
-      match config.remote with
-      | Some r -> Ok r
-      | None -> R.error_msg "Unknown remote repository."))
-  >>= fun remote_repo ->
+  let local_repo = match local_repo with Some r -> r | None -> config.local in
+  let remote_repo =
+    match remote_repo with Some r -> r | None -> config.remote
+  in
   Pkg.infer_github_repo pkg >>= fun { owner; repo } ->
   Config.Draft_release.get ~dry_run ~build_dir ~name:pkg_name ~version
   >>= fun release_id ->

--- a/bin/undraft.ml
+++ b/bin/undraft.ml
@@ -54,7 +54,7 @@ let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo ?remote_repo
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
   in
   (match local_repo with
-  | Some r -> Ok Fpath.(v r)
+  | Some r -> Ok r
   | None -> (
       match config.local with
       | Some r -> Ok r

--- a/bin/undraft.ml
+++ b/bin/undraft.ml
@@ -39,11 +39,12 @@ let update_opam_file ~dry_run ~url pkg =
   App_log.success (fun m ->
       m "Wrote opam package description %a" Text.Pp.path dest_opam_file)
 
-let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo ?remote_repo
-    ?build_dir ?pkg_names ~dry_run ~yes:_ () =
+let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo:local
+    ?remote_repo:remote ?build_dir ?pkg_names ~dry_run ~yes:_ () =
   Config.token ?cli_token:token ~dry_run () >>= fun token ->
   let pkg = Pkg.v ?opam ?distrib_file ?build_dir ~dry_run:false () in
-  Config.v ~local_repo ~remote_repo [ pkg ] >>= fun config ->
+  Config.opam_repo_fork ~pkgs:[ pkg ] ~local ~remote ()
+  >>= fun opam_repo_fork ->
   Pkg.name pkg >>= fun pkg_name ->
   Pkg.build_dir pkg >>= fun build_dir ->
   Pkg.version pkg >>= fun version ->
@@ -52,10 +53,6 @@ let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo ?remote_repo
   let pkg_names = pkg_name :: pkg_names in
   let opam_repo =
     match opam_repo with None -> ("ocaml", "opam-repository") | Some r -> r
-  in
-  let local_repo = match local_repo with Some r -> r | None -> config.local in
-  let remote_repo =
-    match remote_repo with Some r -> r | None -> config.remote
   in
   Pkg.infer_github_repo pkg >>= fun { owner; repo } ->
   Config.Draft_release.get ~dry_run ~build_dir ~name:pkg_name ~version
@@ -89,13 +86,14 @@ let undraft ?opam ?distrib_file ?opam_repo ?token ?local_repo ?remote_repo
     let msg = "Undraft pull-request" in
     Vcs.run_git_quiet vcs ~dry_run Cmd.(v "commit" % "-m" % msg) >>= fun () ->
     App_log.status (fun l ->
-        l "Pushing %a to %a" Text.Pp.commit branch Text.Pp.url remote_repo);
+        l "Pushing %a to %a" Text.Pp.commit branch Text.Pp.url
+          opam_repo_fork.remote);
     Vcs.run_git_quiet vcs ~dry_run
-      Cmd.(v "push" % "--force" % remote_repo % branch)
+      Cmd.(v "push" % "--force" % opam_repo_fork.remote % branch)
   in
   OS.Dir.current () >>= fun cwd ->
   let build_dir = Fpath.(cwd / "_build") in
-  Sos.with_dir ~dry_run local_repo
+  Sos.with_dir ~dry_run opam_repo_fork.local
     (fun () ->
       let upstream =
         let user, repo = opam_repo in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -134,7 +134,7 @@ let create_config ~remote_repo ~local_repo pkgs file =
   in
   let default_local =
     match local_repo with
-    | Some r -> Some r
+    | Some r -> Some (Fpath.to_string r)
     | None -> Some Fpath.(v Xdg.home / "git" / "opam-repository" |> to_string)
   in
   let remote =

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -24,7 +24,7 @@ type t = {
 
 val v :
   remote_repo:string option ->
-  local_repo:string option ->
+  local_repo:Fpath.t option ->
   Pkg.t list ->
   (t, Bos_setup.R.msg) result
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -22,11 +22,9 @@ type t = {
   auto_open : bool option;
 }
 
-val v :
-  remote_repo:string option ->
-  local_repo:Fpath.t option ->
-  Pkg.t list ->
-  (t, Bos_setup.R.msg) result
+module Opam_repo_fork : sig
+  type t = { remote : string; local : Fpath.t }
+end
 
 val create : ?pkgs:Pkg.t list -> unit -> (unit, Bos_setup.R.msg) result
 
@@ -42,6 +40,25 @@ val token :
 val keep_v : bool -> (bool, Bos_setup.R.msg) result
 
 val auto_open : bool -> (bool, Bos_setup.R.msg) result
+
+val opam_repo_fork :
+  ?pkgs:Pkg.t list ->
+  remote:string option ->
+  local:Fpath.t option ->
+  unit ->
+  (Opam_repo_fork.t, Bos_setup.R.msg) result
+(** Returns the opam-repository fork to use, based on the CLI provided values
+    [remote] and [local] and the user's configuration.
+
+    If both [remote] and [local] are provided, they are returned without reading
+    any local configuration.
+
+    If either or both of them are [None], the configuration is looked up. If it
+    doesn't exist, the interactive creation quizz is started. The configuration
+    values are used to fill up the blanks in [remote] and [local].
+
+    [pkgs] is only used to offer suggestions to the user during the creation
+    quizz. *)
 
 val load : unit -> (t option, Bos_setup.R.msg) result
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -16,8 +16,8 @@
 
 type t = {
   user : string option;
-  remote : string option;
-  local : Fpath.t option;
+  remote : string;
+  local : Fpath.t;
   keep_v : bool option;
   auto_open : bool option;
 }
@@ -27,6 +27,8 @@ val v :
   local_repo:Fpath.t option ->
   Pkg.t list ->
   (t, Bos_setup.R.msg) result
+
+val create : ?pkgs:Pkg.t list -> unit -> (unit, Bos_setup.R.msg) result
 
 val token :
   ?cli_token:string -> dry_run:bool -> unit -> (string, Bos_setup.R.msg) result
@@ -41,7 +43,7 @@ val keep_v : bool -> (bool, Bos_setup.R.msg) result
 
 val auto_open : bool -> (bool, Bos_setup.R.msg) result
 
-val load : unit -> (t, Bos_setup.R.msg) result
+val load : unit -> (t option, Bos_setup.R.msg) result
 
 val save : t -> (unit, Bos_setup.R.msg) result
 

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -64,6 +64,8 @@ module Option = struct
 
   let bind ~f = function None -> None | Some x -> f x
 
+  let value ~default opt = match opt with Some x -> x | None -> default
+
   module O = struct
     let ( >>= ) opt f = bind ~f opt
 

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -49,6 +49,8 @@ module Option : sig
 
   val bind : f:('a -> 'b option) -> 'a option -> 'b option
 
+  val value : default:'a -> 'a option -> 'a
+
   module O : sig
     val ( >>= ) : 'a option -> ('a -> 'b option) -> 'b option
 


### PR DESCRIPTION
These options were properly used but they didn't prevent dune-release from accessing the configuration file and eventually, from
creating a new one through interactive prompts. This behaviour prevented it from being used in a CI.

Now the configuration is only looked up (and eventually created) if dune-release doesn't have enough information to proceed with
the release.

In order to fix this I did a few things:
- I made both config fields mandatory, dune-release can't produce a config without those filled up anymore. This used to be pretty much the case but one could manage to do it if they created the config using `dune-release config set`.
- I replaced `Config.v` with an accessor like function, similar to what we use for `keep_v` and `auto_open`. If the CLI provided value is provided, it's used, if we lack information, we look in the config for it. The difference to the above mentioned flags is that we don't have a default value for the opam fork so if there is no config, we start the creation quizz.

The creation quizz also doesn't use the values passed on the CLI as suggestions, this didn't seem sensible to me as the main usecase for using those options is either to run dune-release in a script or a CI or to override the values in the config file.

I also added a `dune-release config create` so one can access the config creation quizz without having to go through an almost full release.

One thing worth noting is that it breaks the behaviour of `dune-release config` when there's no configuration. Before it would either set a single field or display all fields as `<unset>`. I considered this to be okay as I'm not sure anyone was relying on this behaviour but I'm happy to reconsider if you think this is not the right behaviour or that it's too likely to break someone's workflow!