### PR TITLE
Fix --working-tree option

### DIFF
--- a/bin/check.ml
+++ b/bin/check.ml
@@ -58,7 +58,7 @@ let working_tree =
   let doc = "Perform the check on the current working tree." in
   Cli.named
     (fun x -> `Working_tree x)
-    Arg.(value & flag & info [ "working-tree"; "wt" ] ~doc)
+    Arg.(value & flag & info [ "working-tree" ] ~doc)
 
 let doc = "Check dune-release compatibility"
 


### PR DESCRIPTION
The short name wasn't valid as it was longer than one character. We only have the long name now!