### PR TITLE
Upgrade to ocamlformat.0.19.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.17.0
+version=0.19.0
 profile=conventional
 parse-docstrings=true

--- a/bin/help.ml
+++ b/bin/help.ml
@@ -413,7 +413,7 @@ let help man_format topic commands =
   match topic with
   | None -> `Help (man_format, None)
   | Some topic -> (
-      let topics = "topics" :: commands @ List.map fst pages in
+      let topics = ("topics" :: commands) @ List.map fst pages in
       let topics = List.sort compare topics in
       let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
       match conv topic with


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.19.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.