### PR TITLE
Infer version from tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 ### Fixed
 
 - Change the `---V` command option to be `-V` (#388, @Leonidas-from-XIV)
+- Infer release versions are inferred from VCS tags. This change allows using
+  `dune-release` on projects that do not use the changelog or have it in a
+  different format.  (#381, #383 @Leonidas-from-XIV)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Added support for creating releases from unannotated Git tags. `dune-release`
+  supported unannotated tags in a few places already, now it supports using
+  them for creating a release. (#383, @Leonidas-from-XIV)
+
 ### Changed
 
 ### Deprecated

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -9,7 +9,7 @@ open Dune_release
 
 let get_pkg_dir pkg =
   Pkg.build_dir pkg >>= fun bdir ->
-  Pkg.distrib_filename ~opam:true pkg >>= fun fname -> Ok Fpath.(bdir // fname)
+  Pkg.distrib_opam_path pkg >>= fun fname -> Ok Fpath.(bdir // fname)
 
 let rec descr = function
   | [] -> Ok 0

--- a/bin/undraft.ml
+++ b/bin/undraft.ml
@@ -3,7 +3,7 @@ open Dune_release
 
 let get_pkg_dir pkg =
   Pkg.build_dir pkg >>= fun bdir ->
-  Pkg.distrib_filename ~opam:true pkg >>= fun fname -> Ok Fpath.(bdir // fname)
+  Pkg.distrib_opam_path pkg >>= fun fname -> Ok Fpath.(bdir // fname)
 
 let pp_opam_repo fmt opam_repo =
   let user, repo = opam_repo in

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -71,7 +71,8 @@ let version_from_tag pkg =
 
 let extract_version pkg = change_log pkg >>= fun cl -> extract_version cl
 
-let version p = match p.version with Some v -> Ok v | None -> version_from_tag p
+let version p =
+  match p.version with Some v -> Ok v | None -> version_from_tag p
 
 let release_identifier pkg =
   match pkg.tag with
@@ -239,11 +240,6 @@ let distrib_archive_filename_prefix pkg =
   name pkg >>= fun name ->
   release_identifier pkg >>= fun identifier ->
   Fpath.of_string (strf "%s-%s" name identifier)
-
-let distrib_filename ?(opam = false) p =
-  match opam with
-  | true -> distrib_opam_path p
-  | false -> distrib_archive_filename_prefix p
 
 let distrib_archive_path p =
   build_dir p >>= fun build_dir ->
@@ -457,7 +453,7 @@ let distrib_archive ~dry_run ~keep_dir ~include_submodules p =
   build_dir p >>= fun build_dir ->
   tag p >>= fun tag ->
   version p >>= fun version ->
-  distrib_filename p >>= fun root ->
+  distrib_archive_filename_prefix p >>= fun root ->
   Ok Fpath.((build_dir // root) + ".build") >>= fun dist_build_dir ->
   Sos.delete_dir ~dry_run ~force:true dist_build_dir >>= fun () ->
   Vcs.get () >>= fun repo_vcs ->

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -117,9 +117,8 @@ val archive_url_path : t -> (Fpath.t, R.msg) result
 (** [archive_url_path] is the path to the file where the archive download URL is
     saved *)
 
-val distrib_filename : ?opam:bool -> t -> (Fpath.t, R.msg) result
-(** [distrib_filename ~opam p] is a distribution filename for [p]. If [opam] is
-    [true] (defaults to [false]), the name follows opam's naming conventions. *)
+val distrib_opam_path : t -> (Fpath.t, R.msg) result
+(** [distrib_opam_path p] is an opam distribution filename for [p]. *)
 
 (** {1 Uri} *)
 

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -217,13 +217,12 @@ let git_unescape_tag t = String.map (function '_' -> '~' | c -> c) t
 
 (* Hg support *)
 
-(* Mercurial allows everything but :, \r and \n:
- * See https://www.mercurial-scm.org/wiki/Tag
- * This is only handling `:` in the same way as Git above
+(* Mercurial allows everything but :, \r and \n, but all these characters are
+ * unlikely to show up in versions so we just pass things through.
  *)
-let hg_escape_tag t = String.map (function ':' -> '_' | c -> c) t
+let hg_escape_tag t = t
 
-let hg_unescape_tag t = String.map (function '_' -> ':' | c -> c) t
+let hg_unescape_tag t = t
 
 let hg_rev commit_ish = match commit_ish with "HEAD" -> "tip" | c -> c
 

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -134,7 +134,7 @@ let git_describe ~dirty r commit_ish =
   let dirty = dirty && commit_ish = "HEAD" in
   let git_describe =
     Cmd.(
-      git_work_tree r % "describe" % "--always"
+      git_work_tree r % "describe" % "--always" % "--tags"
       %% on dirty (v "--dirty")
       %% on (not dirty) (v commit_ish))
   in

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -217,6 +217,14 @@ let git_unescape_tag t = String.map (function '_' -> '~' | c -> c) t
 
 (* Hg support *)
 
+(* Mercurial allows everything but :, \r and \n:
+ * See https://www.mercurial-scm.org/wiki/Tag
+ * This is only handling `:` in the same way as Git above
+ *)
+let hg_escape_tag t = String.map (function ':' -> '_' | c -> c) t
+
+let hg_unescape_tag t = String.map (function '_' -> ':' | c -> c) t
+
 let hg_rev commit_ish = match commit_ish with "HEAD" -> "tip" | c -> c
 
 let find_hg () =
@@ -302,8 +310,6 @@ let hg_tag r ~force ~sign ~msg ~rev tag =
 
 let hg_delete_tag r tag =
   run_hg r Cmd.(v "tag" % "--remove" % tag) OS.Cmd.out_stdout
-
-let hg_escape_tag t = t
 
 (* Generic VCS support *)
 
@@ -416,7 +422,7 @@ let escape_tag = function
 
 let unescape_tag = function
   | `Git, _, _ -> git_unescape_tag
-  | `Hg, _, _ -> fun x -> x
+  | `Hg, _, _ -> hg_unescape_tag
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -212,7 +212,7 @@ let git_submodule_update ~dry_run r =
 let unallowed_substrings = Re.(compile (alt [ str "@{"; str ".." ]))
 
 (* See the reference here: https://git-scm.com/docs/git-check-ref-format *)
-let git_sanitize_tag t =
+let git_escape_tag t =
   let last = String.length t - 1 in
   if String.equal t "@" then "_AT_"
   else
@@ -326,7 +326,7 @@ let hg_tag r ~force ~sign ~msg ~rev tag =
 let hg_delete_tag r tag =
   run_hg r Cmd.(v "tag" % "--remove" % tag) OS.Cmd.out_stdout
 
-let hg_sanitize_tag t = t
+let hg_escape_tag t = t
 
 (* Generic VCS support *)
 
@@ -433,9 +433,9 @@ let submodule_update ~dry_run r =
   | (`Git, _, _) as r -> git_submodule_update ~dry_run r
   | `Hg, _, _ -> R.error_msgf "submodule update is not supported with mercurial"
 
-let sanitize_tag = function
-  | `Git, _, _ -> git_sanitize_tag
-  | `Hg, _, _ -> hg_sanitize_tag
+let escape_tag = function
+  | `Git, _, _ -> git_escape_tag
+  | `Hg, _, _ -> hg_escape_tag
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -151,10 +151,10 @@ val submodule_update : dry_run:bool -> t -> (unit, R.msg) result
 (** [submodule r] pulls in all submodules in [r]. Only works for git
     repositories *)
 
-val git_sanitize_tag : string -> Tag.t
+val git_escape_tag : string -> Tag.t
 (** Exposed for tests. *)
 
-val sanitize_tag : t -> string -> Tag.t
+val escape_tag : t -> string -> Tag.t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -156,6 +156,11 @@ val git_escape_tag : string -> Tag.t
 
 val escape_tag : t -> string -> Tag.t
 
+val git_unescape_tag : Tag.t -> string
+(** Exposed for tests. *)
+
+val unescape_tag : t -> Tag.t -> string
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/lib/version.ml
+++ b/lib/version.ml
@@ -7,8 +7,8 @@ let drop_initial_v version =
   | Some ('v' | 'V') -> String.with_index_range ~first:1 version
   | None | Some _ -> version
 
-let from_tag ~keep_v t =
-  let s = Vcs.Tag.to_string t in
+let from_tag ~keep_v vcs t =
+  let s = Vcs.unescape_tag vcs t in
   if keep_v then s else drop_initial_v s
 
 let to_tag = Vcs.escape_tag

--- a/lib/version.ml
+++ b/lib/version.ml
@@ -11,7 +11,7 @@ let from_tag ~keep_v t =
   let s = Vcs.Tag.to_string t in
   if keep_v then s else drop_initial_v s
 
-let to_tag = Vcs.sanitize_tag
+let to_tag = Vcs.escape_tag
 
 let of_string x = x
 
@@ -32,5 +32,5 @@ module Changelog = struct
 
   let pp = Fmt.string
 
-  let to_tag = Vcs.sanitize_tag
+  let to_tag = Vcs.escape_tag
 end

--- a/lib/version.mli
+++ b/lib/version.mli
@@ -1,7 +1,7 @@
 type t
 (** [t] represents the high-level version of a project *)
 
-val from_tag : keep_v:bool -> Vcs.Tag.t -> t
+val from_tag : keep_v:bool -> Vcs.t -> Vcs.Tag.t -> t
 (** Constructs a [t] from a [Vcs.Tag.t], possibly dropping the leading v. *)
 
 val to_tag : Vcs.t -> t -> Vcs.Tag.t

--- a/tests/bin/invalid-version-number/run.t
+++ b/tests/bin/invalid-version-number/run.t
@@ -38,8 +38,8 @@ We need to set up a git project for dune-release to work properly
     $ git commit -m "Initial commit" > /dev/null
     $ dune-release tag -y
     [-] Extracting tag from first entry in CHANGES.md
-    [-] Using tag "3.3.4_TILDE_4.10preview1"
-    [+] Tagged HEAD with version 3.3.4_TILDE_4.10preview1
+    [-] Using tag "3.3.4_4.10preview1"
+    [+] Tagged HEAD with version 3.3.4_4.10preview1
 
 We do the whole dune-release process
 
@@ -47,10 +47,10 @@ We do the whole dune-release process
 
     $ dune-release distrib --dry-run | grep preview1
     => rmdir _build/whatever-3.3.4~4.10preview1.build
-         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
-    => exec: git --git-dir .git show -s --format=%ct 3.3.4_TILDE_4.10preview1^0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/3.3.4_4.10preview1
+    => exec: git --git-dir .git show -s --format=%ct 3.3.4_4.10preview1^0
          git --git-dir .git clone --local .git   _build/whatever-3.3.4~4.10preview1.build
-         git --git-dir _build/whatever-3.3.4~4.10preview1.build/.git --work-tree   _build/whatever-3.3.4~4.10preview1.build/ checkout --quiet -b   dune-release-dist-3.3.4_TILDE_4.10preview1 3.3.4_TILDE_4.10preview1
+         git --git-dir _build/whatever-3.3.4~4.10preview1.build/.git --work-tree   _build/whatever-3.3.4~4.10preview1.build/ checkout --quiet -b   dune-release-dist-3.3.4_4.10preview1 3.3.4_4.10preview1
     => chdir _build/whatever-3.3.4~4.10preview1.build
        [in _build/whatever-3.3.4~4.10preview1.build]
     -: rmdir _build/whatever-3.3.4~4.10preview1.build
@@ -72,13 +72,13 @@ We do the whole dune-release process
 
     $ dune-release publish distrib --dry-run --yes | grep preview1
     => must exists _build/whatever-3.3.4~4.10preview1.tbz
-         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
-         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
-         git --git-dir .git ls-remote --quiet --tags https://github.com/user/repo.git   3.3.4_TILDE_4.10preview1
-    [-] Pushing tag 3.3.4_TILDE_4.10preview1 to git@github.com:user/repo.git
-         git --git-dir .git push --force git@github.com:user/repo.git   3.3.4_TILDE_4.10preview1
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/3.3.4_4.10preview1
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/3.3.4_4.10preview1
+         git --git-dir .git ls-remote --quiet --tags https://github.com/user/repo.git   3.3.4_4.10preview1
+    [-] Pushing tag 3.3.4_4.10preview1 to git@github.com:user/repo.git
+         git --git-dir .git push --force git@github.com:user/repo.git   3.3.4_4.10preview1
     [-] Creating release 3.3.4~4.10preview1 on https://github.com/user/repo.git via github's API
-         {"tag_name":"3.3.4_TILDE_4.10preview1","name":"3.3.4~4.10preview1","body":"CHANGES:\n\n- Some other feature\n","draft":false}
+         {"tag_name":"3.3.4_4.10preview1","name":"3.3.4~4.10preview1","body":"CHANGES:\n\n- Some other feature\n","draft":false}
     [-] Uploading _build/whatever-3.3.4~4.10preview1.tbz as a release asset for 3.3.4~4.10preview1 via github's API
          @_build/whatever-3.3.4~4.10preview1.tbz
     -: write _build/whatever-3.3.4~4.10preview1.url

--- a/tests/bin/version-from-tag/dune
+++ b/tests/bin/version-from-tag/dune
@@ -1,0 +1,3 @@
+(mdx
+ (files run.t)
+ (packages dune-release))

--- a/tests/bin/version-from-tag/run.t
+++ b/tests/bin/version-from-tag/run.t
@@ -1,0 +1,142 @@
+We need a basic opam project skeleton
+
+    $ cat > CHANGES.md << EOF \
+    > ## whatever 0.1.0\
+    > \
+    > - Some other feature\
+    > \
+    > ## whatever 0.0.0\
+    > \
+    > - Some feature\
+    > EOF
+    $ cat > whatever.opam << EOF \
+    > opam-version: "2.0"\
+    > homepage: "https://github.com/foo/whatever"\
+    > dev-repo: "git+https://github.com/foo/whatever.git"\
+    > description: "whatever"\
+    > EOF
+    $ touch README.md LICENSE
+    $ cat > dune-project << EOF \
+    > (lang dune 2.4)\
+    > (name whatever)\
+    > EOF
+    $ cat > .gitignore << EOF \
+    > _build/\
+    > .mdx\
+    > run.t\
+    > EOF
+
+We need to set up a git project with two commits to test trying to tag different commits with the same tag name.
+
+    $ git init 2> /dev/null > /dev/null
+    $ git add whatever.opam dune-project .gitignore CHANGES.md README.md LICENSE
+    $ git commit -m "" --allow-empty-message --quiet
+
+Creating a `git tag` manually since the project might be using this workflow
+
+    $ git tag -a 23.0 -m "Release 23.0"
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    [-] Building source archive
+    => rmdir _build/whatever-23.0.build
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/23.0
+    => exec: git --git-dir .git show -s --format=%ct 23.0^0
+    => exec: git --git-dir .git clone --local .git _build/whatever-23.0.build
+    => exec:
+         git --git-dir _build/whatever-23.0.build/.git --work-tree   _build/whatever-23.0.build/ checkout --quiet -b dune-release-dist-23.0 23.0
+    => chdir _build/whatever-23.0.build
+       [in _build/whatever-23.0.build]
+    -: exec: dune subst
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-23.0.build
+    [+] Wrote archive _build/whatever-23.0.tbz
+    => chdir _build/
+       [in _build]
+    => exec: tar -xjf whatever-23.0.tbz
+    
+    [-] Performing lint for package whatever in _build/whatever-23.0
+    => chdir _build/whatever-23.0
+       [in _build/whatever-23.0]
+    => exists ./README.md
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field synopsis is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint of _build/whatever-23.0 and package whatever success
+    
+    [-] Building package in _build/whatever-23.0
+    => chdir _build/whatever-23.0
+    -: exec: dune build -p whatever
+    [ OK ] package(s) build
+    
+    [-] Running package tests in _build/whatever-23.0
+    => chdir _build/whatever-23.0
+    -: exec: dune runtest -p whatever
+    [ OK ] package(s) pass the tests
+    -: rmdir _build/whatever-23.0
+    
+    [+] Distribution for whatever 23.0
+    [+] Archive _build/whatever-23.0.tbz
+
+Also, while not the preferred way, unannotated tags should be possible as well
+
+    $ git commit --allow-empty -m '' --allow-empty-message --quiet
+    $ git tag 42.0
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    [-] Building source archive
+    => rmdir _build/whatever-42.0.build
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/42.0
+    => exec: git --git-dir .git show -s --format=%ct 42.0^0
+    => exec: git --git-dir .git clone --local .git _build/whatever-42.0.build
+    => exec:
+         git --git-dir _build/whatever-42.0.build/.git --work-tree   _build/whatever-42.0.build/ checkout --quiet -b dune-release-dist-42.0 42.0
+    => chdir _build/whatever-42.0.build
+       [in _build/whatever-42.0.build]
+    -: exec: dune subst
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-42.0.build
+    [+] Wrote archive _build/whatever-42.0.tbz
+    => chdir _build/
+       [in _build]
+    => exec: tar -xjf whatever-42.0.tbz
+    
+    [-] Performing lint for package whatever in _build/whatever-42.0
+    => chdir _build/whatever-42.0
+       [in _build/whatever-42.0]
+    => exists ./README.md
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field synopsis is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint of _build/whatever-42.0 and package whatever success
+    
+    [-] Building package in _build/whatever-42.0
+    => chdir _build/whatever-42.0
+    -: exec: dune build -p whatever
+    [ OK ] package(s) build
+    
+    [-] Running package tests in _build/whatever-42.0
+    => chdir _build/whatever-42.0
+    -: exec: dune runtest -p whatever
+    [ OK ] package(s) pass the tests
+    -: rmdir _build/whatever-42.0
+    
+    [+] Distribution for whatever 42.0
+    [+] Archive _build/whatever-42.0.tbz

--- a/tests/bin/version-from-tag/run.t
+++ b/tests/bin/version-from-tag/run.t
@@ -35,166 +35,21 @@ We need to set up a git project with two commits to test trying to tag different
 Creating a `git tag` manually since the project might be using this workflow
 
     $ git tag -a 23.0 -m "Release 23.0"
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
-    [-] Building source archive
-    => rmdir _build/whatever-23.0.build
-    -: exec: git --git-dir .git rev-parse --verify refs/tags/23.0
-    => exec: git --git-dir .git show -s --format=%ct 23.0^0
-    => exec: git --git-dir .git clone --local .git _build/whatever-23.0.build
-    => exec:
-         git --git-dir _build/whatever-23.0.build/.git --work-tree   _build/whatever-23.0.build/ checkout --quiet -b dune-release-dist-23.0 23.0
-    => chdir _build/whatever-23.0.build
-       [in _build/whatever-23.0.build]
-    -: exec: dune subst
-    -: write whatever.opam
-    => exec: bzip2
-    -: rmdir _build/whatever-23.0.build
-    [+] Wrote archive _build/whatever-23.0.tbz
-    => chdir _build/
-       [in _build]
-    => exec: tar -xjf whatever-23.0.tbz
-    
-    [-] Performing lint for package whatever in _build/whatever-23.0
-    => chdir _build/whatever-23.0
-       [in _build/whatever-23.0]
-    => exists ./README.md
-    [ OK ] File README is present.
-    => exists ./LICENSE
-    [ OK ] File LICENSE is present.
-    => exists ./CHANGES.md
-    [ OK ] File CHANGES is present.
-    => exists whatever.opam
-    [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field synopsis is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [ OK ] Skipping doc field linting, no doc field found
-    [ OK ] lint of _build/whatever-23.0 and package whatever success
-    
-    [-] Building package in _build/whatever-23.0
-    => chdir _build/whatever-23.0
-    -: exec: dune build -p whatever
-    [ OK ] package(s) build
-    
-    [-] Running package tests in _build/whatever-23.0
-    => chdir _build/whatever-23.0
-    -: exec: dune runtest -p whatever
-    [ OK ] package(s) pass the tests
-    -: rmdir _build/whatever-23.0
-    
-    [+] Distribution for whatever 23.0
+    $ dune-release distrib --dry-run | grep "Archive _build/"
     [+] Archive _build/whatever-23.0.tbz
 
 Also, while not the preferred way, unannotated tags should be possible as well
 
     $ git commit --allow-empty -m '' --allow-empty-message --quiet
     $ git tag 42.0
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
-    [-] Building source archive
-    => rmdir _build/whatever-42.0.build
-    -: exec: git --git-dir .git rev-parse --verify refs/tags/42.0
-    => exec: git --git-dir .git show -s --format=%ct 42.0^0
-    => exec: git --git-dir .git clone --local .git _build/whatever-42.0.build
-    => exec:
-         git --git-dir _build/whatever-42.0.build/.git --work-tree   _build/whatever-42.0.build/ checkout --quiet -b dune-release-dist-42.0 42.0
-    => chdir _build/whatever-42.0.build
-       [in _build/whatever-42.0.build]
-    -: exec: dune subst
-    -: write whatever.opam
-    => exec: bzip2
-    -: rmdir _build/whatever-42.0.build
-    [+] Wrote archive _build/whatever-42.0.tbz
-    => chdir _build/
-       [in _build]
-    => exec: tar -xjf whatever-42.0.tbz
-    
-    [-] Performing lint for package whatever in _build/whatever-42.0
-    => chdir _build/whatever-42.0
-       [in _build/whatever-42.0]
-    => exists ./README.md
-    [ OK ] File README is present.
-    => exists ./LICENSE
-    [ OK ] File LICENSE is present.
-    => exists ./CHANGES.md
-    [ OK ] File CHANGES is present.
-    => exists whatever.opam
-    [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field synopsis is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [ OK ] Skipping doc field linting, no doc field found
-    [ OK ] lint of _build/whatever-42.0 and package whatever success
-    
-    [-] Building package in _build/whatever-42.0
-    => chdir _build/whatever-42.0
-    -: exec: dune build -p whatever
-    [ OK ] package(s) build
-    
-    [-] Running package tests in _build/whatever-42.0
-    => chdir _build/whatever-42.0
-    -: exec: dune runtest -p whatever
-    [ OK ] package(s) pass the tests
-    -: rmdir _build/whatever-42.0
-    
-    [+] Distribution for whatever 42.0
+    $ dune-release distrib --dry-run | grep "Archive _build/"
     [+] Archive _build/whatever-42.0.tbz
 
 It should also properly map back tags to releases
 
     $ git commit --allow-empty -m '' --allow-empty-message --quiet
     $ git tag -a 1337.0_beta1 -m 'Release 1337~beta1'
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
-    [-] Building source archive
-    => rmdir _build/whatever-1337.0~beta1.build
-    -: exec: git --git-dir .git rev-parse --verify refs/tags/1337.0_beta1
-    => exec: git --git-dir .git show -s --format=%ct 1337.0_beta1^0
-    => exec:
-         git --git-dir .git clone --local .git _build/whatever-1337.0~beta1.build
-    => exec:
-         git --git-dir _build/whatever-1337.0~beta1.build/.git --work-tree   _build/whatever-1337.0~beta1.build/ checkout --quiet -b   dune-release-dist-1337.0_beta1 1337.0_beta1
-    => chdir _build/whatever-1337.0~beta1.build
-       [in _build/whatever-1337.0~beta1.build]
-    -: exec: dune subst
-    -: write whatever.opam
-    => exec: bzip2
-    -: rmdir _build/whatever-1337.0~beta1.build
-    [+] Wrote archive _build/whatever-1337.0~beta1.tbz
-    => chdir _build/
-       [in _build]
-    => exec: tar -xjf whatever-1337.0~beta1.tbz
-    
-    [-] Performing lint for package whatever in _build/whatever-1337.0~beta1
-    => chdir _build/whatever-1337.0~beta1
-       [in _build/whatever-1337.0~beta1]
-    => exists ./README.md
-    [ OK ] File README is present.
-    => exists ./LICENSE
-    [ OK ] File LICENSE is present.
-    => exists ./CHANGES.md
-    [ OK ] File CHANGES is present.
-    => exists whatever.opam
-    [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field synopsis is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [ OK ] Skipping doc field linting, no doc field found
-    [ OK ] lint of _build/whatever-1337.0~beta1 and package whatever success
-    
-    [-] Building package in _build/whatever-1337.0~beta1
-    => chdir _build/whatever-1337.0~beta1
-    -: exec: dune build -p whatever
-    [ OK ] package(s) build
-    
-    [-] Running package tests in _build/whatever-1337.0~beta1
-    => chdir _build/whatever-1337.0~beta1
-    -: exec: dune runtest -p whatever
-    [ OK ] package(s) pass the tests
-    -: rmdir _build/whatever-1337.0~beta1
-    
-    [+] Distribution for whatever 1337.0~beta1
+    $ dune-release distrib --dry-run | grep "Archive _build/"
     [+] Archive _build/whatever-1337.0~beta1.tbz
 
 Also, specifying the tag manually should work
@@ -203,53 +58,5 @@ Also, specifying the tag manually should work
     $ dune-release tag -y 9000_alpha3
     [-] Using tag "9000_alpha3"
     [+] Tagged HEAD with version 9000_alpha3
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
-    [-] Building source archive
-    => rmdir _build/whatever-9000~alpha3.build
-    -: exec: git --git-dir .git rev-parse --verify refs/tags/9000_alpha3
-    => exec: git --git-dir .git show -s --format=%ct 9000_alpha3^0
-    => exec: git --git-dir .git clone --local .git _build/whatever-9000~alpha3.build
-    => exec:
-         git --git-dir _build/whatever-9000~alpha3.build/.git --work-tree   _build/whatever-9000~alpha3.build/ checkout --quiet -b   dune-release-dist-9000_alpha3 9000_alpha3
-    => chdir _build/whatever-9000~alpha3.build
-       [in _build/whatever-9000~alpha3.build]
-    -: exec: dune subst
-    -: write whatever.opam
-    => exec: bzip2
-    -: rmdir _build/whatever-9000~alpha3.build
-    [+] Wrote archive _build/whatever-9000~alpha3.tbz
-    => chdir _build/
-       [in _build]
-    => exec: tar -xjf whatever-9000~alpha3.tbz
-    
-    [-] Performing lint for package whatever in _build/whatever-9000~alpha3
-    => chdir _build/whatever-9000~alpha3
-       [in _build/whatever-9000~alpha3]
-    => exists ./README.md
-    [ OK ] File README is present.
-    => exists ./LICENSE
-    [ OK ] File LICENSE is present.
-    => exists ./CHANGES.md
-    [ OK ] File CHANGES is present.
-    => exists whatever.opam
-    [ OK ] File opam is present.
-    -: exec: opam lint -s whatever.opam
-    [ OK ] lint opam file whatever.opam.
-    [ OK ] opam field synopsis is present
-    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
-    [ OK ] Skipping doc field linting, no doc field found
-    [ OK ] lint of _build/whatever-9000~alpha3 and package whatever success
-    
-    [-] Building package in _build/whatever-9000~alpha3
-    => chdir _build/whatever-9000~alpha3
-    -: exec: dune build -p whatever
-    [ OK ] package(s) build
-    
-    [-] Running package tests in _build/whatever-9000~alpha3
-    => chdir _build/whatever-9000~alpha3
-    -: exec: dune runtest -p whatever
-    [ OK ] package(s) pass the tests
-    -: rmdir _build/whatever-9000~alpha3
-    
-    [+] Distribution for whatever 9000~alpha3
+    $ dune-release distrib --dry-run | grep "Archive _build/"
     [+] Archive _build/whatever-9000~alpha3.tbz

--- a/tests/bin/version-from-tag/run.t
+++ b/tests/bin/version-from-tag/run.t
@@ -140,3 +140,116 @@ Also, while not the preferred way, unannotated tags should be possible as well
     
     [+] Distribution for whatever 42.0
     [+] Archive _build/whatever-42.0.tbz
+
+It should also properly map back tags to releases
+
+    $ git commit --allow-empty -m '' --allow-empty-message --quiet
+    $ git tag -a 1337.0_beta1 -m 'Release 1337~beta1'
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    [-] Building source archive
+    => rmdir _build/whatever-1337.0~beta1.build
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/1337.0_beta1
+    => exec: git --git-dir .git show -s --format=%ct 1337.0_beta1^0
+    => exec:
+         git --git-dir .git clone --local .git _build/whatever-1337.0~beta1.build
+    => exec:
+         git --git-dir _build/whatever-1337.0~beta1.build/.git --work-tree   _build/whatever-1337.0~beta1.build/ checkout --quiet -b   dune-release-dist-1337.0_beta1 1337.0_beta1
+    => chdir _build/whatever-1337.0~beta1.build
+       [in _build/whatever-1337.0~beta1.build]
+    -: exec: dune subst
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-1337.0~beta1.build
+    [+] Wrote archive _build/whatever-1337.0~beta1.tbz
+    => chdir _build/
+       [in _build]
+    => exec: tar -xjf whatever-1337.0~beta1.tbz
+    
+    [-] Performing lint for package whatever in _build/whatever-1337.0~beta1
+    => chdir _build/whatever-1337.0~beta1
+       [in _build/whatever-1337.0~beta1]
+    => exists ./README.md
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field synopsis is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint of _build/whatever-1337.0~beta1 and package whatever success
+    
+    [-] Building package in _build/whatever-1337.0~beta1
+    => chdir _build/whatever-1337.0~beta1
+    -: exec: dune build -p whatever
+    [ OK ] package(s) build
+    
+    [-] Running package tests in _build/whatever-1337.0~beta1
+    => chdir _build/whatever-1337.0~beta1
+    -: exec: dune runtest -p whatever
+    [ OK ] package(s) pass the tests
+    -: rmdir _build/whatever-1337.0~beta1
+    
+    [+] Distribution for whatever 1337.0~beta1
+    [+] Archive _build/whatever-1337.0~beta1.tbz
+
+Also, specifying the tag manually should work
+
+    $ git commit --allow-empty -m '' --allow-empty-message --quiet
+    $ dune-release tag -y 9000_alpha3
+    [-] Using tag "9000_alpha3"
+    [+] Tagged HEAD with version 9000_alpha3
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    [-] Building source archive
+    => rmdir _build/whatever-9000~alpha3.build
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/9000_alpha3
+    => exec: git --git-dir .git show -s --format=%ct 9000_alpha3^0
+    => exec: git --git-dir .git clone --local .git _build/whatever-9000~alpha3.build
+    => exec:
+         git --git-dir _build/whatever-9000~alpha3.build/.git --work-tree   _build/whatever-9000~alpha3.build/ checkout --quiet -b   dune-release-dist-9000_alpha3 9000_alpha3
+    => chdir _build/whatever-9000~alpha3.build
+       [in _build/whatever-9000~alpha3.build]
+    -: exec: dune subst
+    -: write whatever.opam
+    => exec: bzip2
+    -: rmdir _build/whatever-9000~alpha3.build
+    [+] Wrote archive _build/whatever-9000~alpha3.tbz
+    => chdir _build/
+       [in _build]
+    => exec: tar -xjf whatever-9000~alpha3.tbz
+    
+    [-] Performing lint for package whatever in _build/whatever-9000~alpha3
+    => chdir _build/whatever-9000~alpha3
+       [in _build/whatever-9000~alpha3]
+    => exists ./README.md
+    [ OK ] File README is present.
+    => exists ./LICENSE
+    [ OK ] File LICENSE is present.
+    => exists ./CHANGES.md
+    [ OK ] File CHANGES is present.
+    => exists whatever.opam
+    [ OK ] File opam is present.
+    -: exec: opam lint -s whatever.opam
+    [ OK ] lint opam file whatever.opam.
+    [ OK ] opam field synopsis is present
+    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+    [ OK ] Skipping doc field linting, no doc field found
+    [ OK ] lint of _build/whatever-9000~alpha3 and package whatever success
+    
+    [-] Building package in _build/whatever-9000~alpha3
+    => chdir _build/whatever-9000~alpha3
+    -: exec: dune build -p whatever
+    [ OK ] package(s) build
+    
+    [-] Running package tests in _build/whatever-9000~alpha3
+    => chdir _build/whatever-9000~alpha3
+    -: exec: dune runtest -p whatever
+    [ OK ] package(s) pass the tests
+    -: rmdir _build/whatever-9000~alpha3
+    
+    [+] Distribution for whatever 9000~alpha3
+    [+] Archive _build/whatever-9000~alpha3.tbz

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -101,26 +101,27 @@ let distrib_opam_path =
     make_test ~test_name ~name:"foo" Pkg.distrib_opam_path
   in
   [
-    make_test ~test_name:"2" ~tag:"v0" "foo.0";
-    make_test ~test_name:"4" ~version:"v0" "foo.v0";
-    make_test ~test_name:"6" ~tag:"v0" ~keep_v:false "foo.0";
-    make_test ~test_name:"8" ~tag:"v0" ~keep_v:true "foo.v0";
-    make_test ~test_name:"10" ~tag:"v0" ~version:"x" "foo.x";
+    make_test ~test_name:"from version while keeping v" ~version:"v0"
+      ~keep_v:true "foo.v0";
+    make_test ~test_name:"from version without keeping v" ~version:"v0"
+      ~keep_v:false "foo.v0";
+    make_test ~test_name:"from version and tag" ~tag:"v0" ~version:"x" "foo.x";
   ]
 
 let distrib_archive_path =
-  let make_test ?version ?tag ?keep_v ?opam ~test_name expected =
+  let make_test ~test_name =
     let test_name = "distrib_archive_path: " ^ test_name in
-    let expected = Fmt.strf "_build/%s.tbz" expected in
-    make_test ?version ?tag ?keep_v ?opam ~test_name ~name:"foo"
-      Pkg.distrib_archive_path expected
+    make_test ~test_name ~name:"foo" Pkg.distrib_archive_path
   in
   [
-    make_test ~test_name:"1" ~tag:"v0" "foo-v0";
-    make_test ~test_name:"3" ~version:"v0" "foo-v0";
-    make_test ~test_name:"5" ~tag:"v0" ~keep_v:false "foo-v0";
-    make_test ~test_name:"7" ~tag:"v0" ~keep_v:true "foo-v0";
-    make_test ~test_name:"9" ~tag:"v0" ~version:"x" "foo-v0";
+    make_test ~test_name:"from tag" ~tag:"v0" "_build/foo-v0.tbz";
+    make_test ~test_name:"from version" ~version:"v0" "_build/foo-v0.tbz";
+    make_test ~test_name:"from tag without keeping v" ~tag:"v0" ~keep_v:false
+      "_build/foo-v0.tbz";
+    make_test ~test_name:"from tag with keeping v" ~tag:"v0" ~keep_v:true
+      "_build/foo-v0.tbz";
+    make_test ~test_name:"from version and tag" ~tag:"v0" ~version:"x"
+      "_build/foo-v0.tbz";
   ]
 
 let distrib_uri =

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -95,22 +95,32 @@ let distrib_file =
       "_build/foo-v0.tbz";
   ]
 
-let distrib_filename =
-  let make_test ~test_name ~opam =
-    let test_name = "distrib_filename: " ^ test_name in
-    make_test ~test_name ~name:"foo" (Pkg.distrib_filename ~opam)
+let distrib_opam_path =
+  let make_test ~test_name =
+    let test_name = "distrib_opam_path: " ^ test_name in
+    make_test ~test_name ~name:"foo" Pkg.distrib_opam_path
   in
   [
-    make_test ~test_name:"1" ~opam:false ~tag:"v0" "foo-v0";
-    make_test ~test_name:"2" ~opam:true ~tag:"v0" "foo.0";
-    make_test ~test_name:"3" ~opam:false ~version:"v0" "foo-v0";
-    make_test ~test_name:"4" ~opam:true ~version:"v0" "foo.v0";
-    make_test ~test_name:"5" ~opam:false ~tag:"v0" ~keep_v:false "foo-v0";
-    make_test ~test_name:"6" ~opam:true ~tag:"v0" ~keep_v:false "foo.0";
-    make_test ~test_name:"7" ~opam:false ~tag:"v0" ~keep_v:true "foo-v0";
-    make_test ~test_name:"8" ~opam:true ~tag:"v0" ~keep_v:true "foo.v0";
-    make_test ~test_name:"9" ~opam:false ~tag:"v0" ~version:"x" "foo-v0";
-    make_test ~test_name:"10" ~opam:true ~tag:"v0" ~version:"x" "foo.x";
+    make_test ~test_name:"2" ~tag:"v0" "foo.0";
+    make_test ~test_name:"4" ~version:"v0" "foo.v0";
+    make_test ~test_name:"6" ~tag:"v0" ~keep_v:false "foo.0";
+    make_test ~test_name:"8" ~tag:"v0" ~keep_v:true "foo.v0";
+    make_test ~test_name:"10" ~tag:"v0" ~version:"x" "foo.x";
+  ]
+
+let distrib_archive_path =
+  let make_test ?version ?tag ?keep_v ?opam ~test_name expected =
+    let test_name = "distrib_archive_path: " ^ test_name in
+    let expected = Fmt.strf "_build/%s.tbz" expected in
+    make_test ?version ?tag ?keep_v ?opam ~test_name ~name:"foo"
+      Pkg.distrib_archive_path expected
+  in
+  [
+    make_test ~test_name:"1" ~tag:"v0" "foo-v0";
+    make_test ~test_name:"3" ~version:"v0" "foo-v0";
+    make_test ~test_name:"5" ~tag:"v0" ~keep_v:false "foo-v0";
+    make_test ~test_name:"7" ~tag:"v0" ~keep_v:true "foo-v0";
+    make_test ~test_name:"9" ~tag:"v0" ~version:"x" "foo-v0";
   ]
 
 let distrib_uri =
@@ -143,6 +153,7 @@ let suite =
         test_version_line_re;
         test_prepare_opam_for_distrib;
         distrib_file;
-        distrib_filename;
+        distrib_opam_path;
+        distrib_archive_path;
         distrib_uri;
       ] )

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -80,50 +80,6 @@ let make_test f ?version ?tag ?keep_v ?opam ~test_name ~name expected =
   in
   (test_name, `Quick, test)
 
-let distrib_file =
-  let make_test ~test_name =
-    let test_name = "distrib_file: " ^ test_name in
-    make_test ~test_name ~name:"foo" Pkg.(distrib_file ~dry_run:true)
-  in
-  [
-    make_test ~test_name:"tag" ~tag:"v0" "_build/foo-v0.tbz";
-    make_test ~test_name:"version" ~version:"v0" "_build/foo-v0.tbz";
-    make_test ~test_name:"tag without v" ~tag:"v0" ~keep_v:false
-      "_build/foo-v0.tbz";
-    make_test ~test_name:"tag with v" ~tag:"v0" ~keep_v:true "_build/foo-v0.tbz";
-    make_test ~test_name:"tag and version" ~tag:"v0" ~version:"x"
-      "_build/foo-v0.tbz";
-  ]
-
-let distrib_opam_path =
-  let make_test ~test_name =
-    let test_name = "distrib_opam_path: " ^ test_name in
-    make_test ~test_name ~name:"foo" Pkg.distrib_opam_path
-  in
-  [
-    make_test ~test_name:"from version while keeping v" ~version:"v0"
-      ~keep_v:true "foo.v0";
-    make_test ~test_name:"from version without keeping v" ~version:"v0"
-      ~keep_v:false "foo.v0";
-    make_test ~test_name:"from version and tag" ~tag:"v0" ~version:"x" "foo.x";
-  ]
-
-let distrib_archive_path =
-  let make_test ~test_name =
-    let test_name = "distrib_archive_path: " ^ test_name in
-    make_test ~test_name ~name:"foo" Pkg.distrib_archive_path
-  in
-  [
-    make_test ~test_name:"from tag" ~tag:"v0" "_build/foo-v0.tbz";
-    make_test ~test_name:"from version" ~version:"v0" "_build/foo-v0.tbz";
-    make_test ~test_name:"from tag without keeping v" ~tag:"v0" ~keep_v:false
-      "_build/foo-v0.tbz";
-    make_test ~test_name:"from tag with keeping v" ~tag:"v0" ~keep_v:true
-      "_build/foo-v0.tbz";
-    make_test ~test_name:"from version and tag" ~tag:"v0" ~version:"x"
-      "_build/foo-v0.tbz";
-  ]
-
 let distrib_uri =
   let make_test ~test_name =
     let test_name = "distrib_uri:" ^ test_name in
@@ -150,11 +106,4 @@ let distrib_uri =
 let suite =
   ( "Pkg",
     List.concat
-      [
-        test_version_line_re;
-        test_prepare_opam_for_distrib;
-        distrib_file;
-        distrib_opam_path;
-        distrib_archive_path;
-        distrib_uri;
-      ] )
+      [ test_version_line_re; test_prepare_opam_for_distrib; distrib_uri ] )

--- a/tests/lib/test_vcs.ml
+++ b/tests/lib/test_vcs.ml
@@ -1,25 +1,40 @@
 module Vcs = Dune_release.Vcs
 
-let test_git_sanitize_tag =
+let make_test name ~input ~expected ~prefix ~f =
+  let name = Printf.sprintf "%s: %s" prefix name in
+  let test_fun () = Alcotest.(check string) name expected (f input) in
+  (name, `Quick, test_fun)
+
+let t = Vcs.Tag.of_string
+
+let test_git_escape_tag =
   let make_test name ~input ~expected =
-    let expected = Vcs.Tag.of_string expected in
-    let name = "git_sanitize_tag: " ^ name in
+    let name = Printf.sprintf "git_escape_tag: %s" name in
     let test_fun () =
-      Alcotest.(check Alcotest_ext.tag)
-        name expected
-        (Vcs.git_escape_tag input)
+      Alcotest.(check Alcotest_ext.tag) name expected (Vcs.git_escape_tag input)
     in
     (name, `Quick, test_fun)
   in
   [
-    make_test "empty" ~input:"" ~expected:"";
-    make_test "valid" ~input:"3.3.4" ~expected:"3.3.4";
+    make_test "empty" ~input:"" ~expected:(t "");
+    make_test "valid" ~input:"3.3.4" ~expected:(t "3.3.4");
     make_test "tilde" ~input:"3.3.4~4.10preview1"
-      ~expected:"3.3.4_TILDE_4.10preview1";
-    make_test "slash first" ~input:"/v" ~expected:"_SLASH_v";
-    make_test "slash not first" ~input:"v/v" ~expected:"v/v";
-    make_test "dot last" ~input:"v." ~expected:"v_DOT_";
-    make_test "dot not last" ~input:"v.v" ~expected:"v.v";
+      ~expected:(t "3.3.4_4.10preview1");
   ]
 
-let suite = ("Vcs", test_git_sanitize_tag)
+let test_git_unescape_tag =
+  let make_test name ~input ~expected =
+    let name = Printf.sprintf "git_unescape_tag: %s" name in
+    let test_fun () =
+      Alcotest.(check string) name expected (Vcs.git_unescape_tag input)
+    in
+    (name, `Quick, test_fun)
+  in
+  [
+    make_test "empty" ~input:(t "") ~expected:"";
+    make_test "valid" ~input:(t "3.3.4") ~expected:"3.3.4";
+    make_test "tilde" ~input:(t "3.3.4_4.10preview1")
+      ~expected:"3.3.4~4.10preview1";
+  ]
+
+let suite = ("Vcs", test_git_escape_tag @ test_git_unescape_tag)

--- a/tests/lib/test_vcs.ml
+++ b/tests/lib/test_vcs.ml
@@ -5,36 +5,34 @@ let make_test name ~input ~expected ~prefix ~f =
   let test_fun () = Alcotest.(check string) name expected (f input) in
   (name, `Quick, test_fun)
 
-let t = Vcs.Tag.of_string
-
 let test_git_escape_tag =
   let make_test name ~input ~expected =
     let name = Printf.sprintf "git_escape_tag: %s" name in
+    let expected = Vcs.Tag.of_string expected in
     let test_fun () =
       Alcotest.(check Alcotest_ext.tag) name expected (Vcs.git_escape_tag input)
     in
     (name, `Quick, test_fun)
   in
   [
-    make_test "empty" ~input:"" ~expected:(t "");
-    make_test "valid" ~input:"3.3.4" ~expected:(t "3.3.4");
-    make_test "tilde" ~input:"3.3.4~4.10preview1"
-      ~expected:(t "3.3.4_4.10preview1");
+    make_test "empty" ~input:"" ~expected:"";
+    make_test "valid" ~input:"3.3.4" ~expected:"3.3.4";
+    make_test "tilde" ~input:"3.3.4~4.10preview1" ~expected:"3.3.4_4.10preview1";
   ]
 
 let test_git_unescape_tag =
   let make_test name ~input ~expected =
     let name = Printf.sprintf "git_unescape_tag: %s" name in
+    let input = Vcs.Tag.of_string input in
     let test_fun () =
       Alcotest.(check string) name expected (Vcs.git_unescape_tag input)
     in
     (name, `Quick, test_fun)
   in
   [
-    make_test "empty" ~input:(t "") ~expected:"";
-    make_test "valid" ~input:(t "3.3.4") ~expected:"3.3.4";
-    make_test "tilde" ~input:(t "3.3.4_4.10preview1")
-      ~expected:"3.3.4~4.10preview1";
+    make_test "empty" ~input:"" ~expected:"";
+    make_test "valid" ~input:"3.3.4" ~expected:"3.3.4";
+    make_test "tilde" ~input:"3.3.4_4.10preview1" ~expected:"3.3.4~4.10preview1";
   ]
 
 let suite = ("Vcs", test_git_escape_tag @ test_git_unescape_tag)

--- a/tests/lib/test_vcs.ml
+++ b/tests/lib/test_vcs.ml
@@ -7,7 +7,7 @@ let test_git_sanitize_tag =
     let test_fun () =
       Alcotest.(check Alcotest_ext.tag)
         name expected
-        (Vcs.git_sanitize_tag input)
+        (Vcs.git_escape_tag input)
     in
     (name, `Quick, test_fun)
   in


### PR DESCRIPTION
This changes the source from where to read the version from the changelog to the tag. To be able to serialize typical versions into git tags it uses a simplified convention of [DEP-14](https://dep-team.pages.debian.net/deps/dep14/): `~` becomes `_` and vice versa.

Checking opam-repository for "exotic" versions with

```sh
fd --type d '.+\..+' | rg '\.(.+)' --replace '$1' --only-matching | rg '[^-\.\d\w+~]''
```

Yields that once dots, digits, letters, `-`, `+` and `~` are excluded, there are no other surprising characters that we need to be careful in practice.

This also allows users of `dune-release` that aren't using the changelog file as source of truth use the tool and even maps tags like `1.3_beta3` into OPAM compatible `1.3~beta3` which could be quite useful.

Fixes #381