### PR TITLE
Fix `---V` to be `-V`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Change the `---V` command option to be `-V` (#388, @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -55,7 +55,7 @@ let pkg_version =
   named
     (fun x -> `Package_version x)
     Arg.(
-      value & opt (some string) None & info [ "-V"; "pkg-version" ] ~doc ~docv)
+      value & opt (some string) None & info [ "V"; "pkg-version" ] ~doc ~docv)
 
 let opam =
   let doc =


### PR DESCRIPTION
Cmdliner accepts everything that is longer than one character as a long option, hence it made `-V` into `---V` long option.

This has been broken since `-V` was added in https://github.com/ocamllabs/dune-release/commit/809f5391dad64c32d381c550dc56ec4233336b1a, so maybe nobody uses it and it might sense to just remove that option?