### PR TITLE
Check for the tag to be a tag, not just a valid ref

### DIFF
--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -141,7 +141,8 @@ let git_describe ~dirty r commit_ish =
   run_git_string ~dry_run:false r git_describe ~default:Default.string
 
 let git_tag_exists ~dry_run r tag =
-  match run_git_quiet ~dry_run r Cmd.(v "rev-parse" % "--verify" % tag) with
+  let tag_rev = "refs/tags/" ^ tag in
+  match run_git_quiet ~dry_run r Cmd.(v "rev-parse" % "--verify" % tag_rev) with
   | Ok () -> true
   | _ -> false
 

--- a/tests/bin/distrib-name/run.t
+++ b/tests/bin/distrib-name/run.t
@@ -53,6 +53,10 @@ this name must be one the .opam file names.)
 
 Run dune-release distrib with the uncomitted name in dune-project.
 
+    $ dune-release tag -y
+    [-] Extracting tag from first entry in CHANGES.md
+    [-] Using tag "0.42.0"
+    [+] Tagged HEAD with version 0.42.0
     $ dune-release distrib --skip-lint
     [-] Building source archive
     dune-release: [WARNING] The repo is dirty. The distribution archive may be
@@ -66,7 +70,6 @@ Run dune-release distrib with the uncomitted name in dune-project.
 Commit the change in dune-project and run distrib.
 
     $ git add dune-project && git commit -m 'add name' > /dev/null
-
     $ dune-release distrib --skip-lint
     [-] Building source archive
     [+] Wrote archive ...

--- a/tests/bin/draft/run.t
+++ b/tests/bin/draft/run.t
@@ -55,7 +55,7 @@ We do the whole dune-release process
     => must exists _build/whatever-0.1.0.tbz
     [-] Publishing to github
     ...
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     -: exec:
          git --git-dir .git ls-remote --quiet --tags   https://github.com/foo/whatever.git 0.1.0
     [?] Push tag 0.1.0 to git@github.com:foo/whatever.git? [Y/n]

--- a/tests/bin/invalid-version-number/run.t
+++ b/tests/bin/invalid-version-number/run.t
@@ -47,7 +47,7 @@ We do the whole dune-release process
 
     $ dune-release distrib --dry-run | grep preview1
     => rmdir _build/whatever-3.3.4~4.10preview1.build
-    -: exec: git --git-dir .git rev-parse --verify 3.3.4_TILDE_4.10preview1
+         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
     => exec: git --git-dir .git show -s --format=%ct 3.3.4_TILDE_4.10preview1^0
          git --git-dir .git clone --local .git   _build/whatever-3.3.4~4.10preview1.build
          git --git-dir _build/whatever-3.3.4~4.10preview1.build/.git --work-tree   _build/whatever-3.3.4~4.10preview1.build/ checkout --quiet -b   dune-release-dist-3.3.4_TILDE_4.10preview1 3.3.4_TILDE_4.10preview1
@@ -72,8 +72,8 @@ We do the whole dune-release process
 
     $ dune-release publish distrib --dry-run --yes | grep preview1
     => must exists _build/whatever-3.3.4~4.10preview1.tbz
-    -: exec: git --git-dir .git rev-parse --verify 3.3.4_TILDE_4.10preview1
-    -: exec: git --git-dir .git rev-parse --verify 3.3.4_TILDE_4.10preview1
+         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
+         git --git-dir .git rev-parse --verify refs/tags/3.3.4_TILDE_4.10preview1
          git --git-dir .git ls-remote --quiet --tags https://github.com/user/repo.git   3.3.4_TILDE_4.10preview1
     [-] Pushing tag 3.3.4_TILDE_4.10preview1 to git@github.com:user/repo.git
          git --git-dir .git push --force git@github.com:user/repo.git   3.3.4_TILDE_4.10preview1

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -45,10 +45,12 @@ We do the whole dune-release process
 
 (1) distrib
 
-    $ dune-release distrib --dry-run
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    dune-release: [ERROR] Github development repository URL could not be
+                          inferred.
     [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0
     => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
     => exec:
@@ -79,8 +81,6 @@ We do the whole dune-release process
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field synopsis is present
     [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
-    dune-release: [ERROR] Github development repository URL could not be
-                          inferred.
     [FAIL] opam field doc cannot be parsed by dune-release
     [FAIL] lint of _build/whatever-0.1.0 and package whatever failure: 1 errors.
     
@@ -95,9 +95,7 @@ We do the whole dune-release process
     [ OK ] package(s) pass the tests
     
     [+] Distribution for whatever 0.1.0
-    [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
-    [1]
 
 (2) publish doc
 

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -45,10 +45,9 @@ We do the whole dune-release process
 
 (1) distrib
 
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}" | grep -v "Building source archive"
     dune-release: [ERROR] Github development repository URL could not be
                           inferred.
-    [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
     -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -45,10 +45,9 @@ We do the whole dune-release process
 
 (1) distrib
 
-    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}" | grep -v "Building source archive"
     dune-release: [ERROR] Github development repository URL could not be
                           inferred.
-    [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
     -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -45,10 +45,12 @@ We do the whole dune-release process
 
 (1) distrib
 
-    $ dune-release distrib --dry-run
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
+    dune-release: [ERROR] Github development repository URL could not be
+                          inferred.
     [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0
     => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
     => exec:
@@ -79,8 +81,6 @@ We do the whole dune-release process
     [ OK ] lint opam file whatever.opam.
     [ OK ] opam field synopsis is present
     [FAIL] opam fields homepage and dev-repo can be parsed by dune-release
-    dune-release: [ERROR] Github development repository URL could not be
-                          inferred.
     [ OK ] Skipping doc field linting, no doc field found
     [FAIL] lint of _build/whatever-0.1.0 and package whatever failure: 1 errors.
     
@@ -95,9 +95,7 @@ We do the whole dune-release process
     [ OK ] package(s) pass the tests
     
     [+] Distribution for whatever 0.1.0
-    [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
-    [1]
 
 (2) publish distrib
 

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -45,10 +45,10 @@ We make a dry-run release:
 
 (1) Creating the distribution archive
 
-    $ dune-release distrib --dry-run
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
     [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0
     => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
     => exec:
@@ -94,7 +94,6 @@ We make a dry-run release:
     -: rmdir _build/whatever-0.1.0
     
     [+] Distribution for whatever 0.1.0
-    [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
 
 
@@ -106,7 +105,7 @@ We make a dry-run release:
     => must exists _build/whatever-0.1.0.tbz
     [-] Publishing to github
     ...
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     ...
     [?] Create release 0.1.0 on https://github.com/foo/whatever.git? [Y/n]
     [-] Creating release 0.1.0 on https://github.com/foo/whatever.git via github's API

--- a/tests/bin/x-commit-hash/run.t
+++ b/tests/bin/x-commit-hash/run.t
@@ -44,10 +44,10 @@ We need to set up a git project for dune-release to work properly
 
 We make a dry-run release
 
-    $ dune-release distrib --dry-run
+    $ dune-release distrib --dry-run | grep -vE "Commit [a-f0-9]{40}"
     [-] Building source archive
     => rmdir _build/whatever-0.1.0.build
-    -: exec: git --git-dir .git rev-parse --verify 0.1.0
+    -: exec: git --git-dir .git rev-parse --verify refs/tags/0.1.0
     => exec: git --git-dir .git show -s --format=%ct 0.1.0^0
     => exec: git --git-dir .git clone --local .git _build/whatever-0.1.0.build
     => exec:
@@ -93,7 +93,6 @@ We make a dry-run release
     -: rmdir _build/whatever-0.1.0
     
     [+] Distribution for whatever 0.1.0
-    [+] Commit ...
     [+] Archive _build/whatever-0.1.0.tbz
 
 We create an opam package:


### PR DESCRIPTION
The code just checked the ref to exist which checked whether the ref existed. When passing in an (existing) commit hash this would return true, because a commit hash is a valid ref, but it is not a tag. This changes the code so it actually tests that the passed reference is indeed a tag.

I ran across this as I was accidentally passing commithashes to it (since the tagging failed) and it still accepted them.

This is not a user visible change, so I'm not adding this to the changelog, this is purely about correctness of the code.