### PR TITLE
Revert use-yaml branch merge

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,5 +39,4 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   odoc
   (alcotest :with-test)
   (mdx (and :with-test (>= 1.6.0)))
-  yaml
   yojson))

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -34,7 +34,6 @@ depends: [
   "odoc"
   "alcotest" {with-test}
   "mdx" {with-test & >= "1.6.0"}
-  "yaml"
   "yojson"
 ]
 build: [

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -30,46 +30,49 @@ type t = {
 
 module Opam_repo_fork = struct
   type t = { remote : string; local : Fpath.t }
-
-  let err_msg =
-    Rresult.R.msg
-      "Dune-release configuration file is invalid: both local and remote field \
-       should be set"
-
-  let of_yaml_values dict =
-    let rec aux ((r, l) as acc) = function
-      | [] -> Ok acc
-      | ("remote", `String s) :: t -> aux (`Remote (Some s), l) t
-      | ("local", `String s) :: t ->
-          Fpath.of_string s >>= fun s -> aux (r, `Local (Some s)) t
-      | _ :: t -> aux acc t
-    in
-    aux (`Remote None, `Local None) dict >>= fun (`Remote r, `Local l) ->
-    Stdext.Option.to_result ~none:err_msg r >>= fun remote ->
-    Stdext.Option.to_result ~none:err_msg l >>= fun local ->
-    Ok { remote; local }
 end
 
-let of_yaml str =
-  Yaml.of_string str >>= function
-  | `O dict ->
-      let rec aux acc = function
-        | [] -> Ok acc
-        | ("user", `String s) :: t -> aux { acc with user = Some s } t
-        | ("remote", `String _) :: t -> aux acc t
-        | ("local", `String _) :: t -> aux acc t
-        | ("auto-open", `Bool b) :: t -> aux { acc with auto_open = Some b } t
-        | ("keep-v", `Bool b) :: t -> aux { acc with keep_v = Some b } t
-        | (key, _) :: _ ->
-            R.error_msgf "%S is not a valid configuration key." key
-      in
-      Opam_repo_fork.of_yaml_values dict >>= fun { remote; local } ->
-      aux { user = None; remote; local; auto_open = None; keep_v = None } dict
-  | value ->
-      R.error_msgf
-        "Expected fields `user', `remote', `local', `auto-open' and `keep-v`, \
-         got %a"
-        Yaml.pp value
+let of_yaml_exn str =
+  (* ouch *)
+  let lines = String.cuts ~empty:false ~sep:"\n" str in
+  let dict () =
+    List.map
+      (fun line ->
+        match String.cut ~sep:":" line with
+        | Some (k, v) -> (String.trim k, String.trim v)
+        | _ -> failwith "invalid format")
+      lines
+  in
+  let dict = dict () in
+  let find k = try Some (List.assoc k dict) with Not_found -> None in
+  let find_b k =
+    match find k with None -> None | Some s -> Some (bool_of_string s)
+  in
+  let valid = [ "user"; "remote"; "local"; "auto-open"; "keep-v" ] in
+  List.iter
+    (fun (k, _) ->
+      if not (List.mem k valid) then
+        Fmt.failwith "%S is not a valid configuration key." k)
+    dict;
+  let opam_repo_fork =
+    match (find "local", find "remote") with
+    | Some local_str, Some remote ->
+        Fpath.of_string local_str >>| fun local -> (local, remote)
+    | _ ->
+        Rresult.R.error_msg
+          "Dune-release configuration file is compromised: both local and \
+           remote field should be set"
+  in
+  opam_repo_fork >>| fun (local, remote) ->
+  {
+    user = find "user";
+    remote;
+    local;
+    auto_open = find_b "auto-open";
+    keep_v = find_b "keep-v";
+  }
+
+let of_yaml str = try of_yaml_exn str with Failure s -> R.error_msg s
 
 let config_dir () =
   let cfg = Fpath.(v Xdg.config_dir / "dune") in
@@ -155,6 +158,11 @@ let create ?pkgs () =
   get_path () >>= fun file ->
   create_config ?pkgs file >>= fun _ -> Ok ()
 
+let find () =
+  get_path () >>= fun file ->
+  OS.File.exists file >>= fun exists ->
+  if exists then OS.File.read file >>= of_yaml >>| fun x -> Some x else Ok None
+
 let reset_terminal : (unit -> unit) option ref = ref None
 
 let cleanup () = match !reset_terminal with None -> () | Some f -> f ()
@@ -234,7 +242,7 @@ let token ~token ~dry_run () =
   | Some token -> Ok token
   | None -> config_token ~dry_run ()
 
-let file = lazy (load ())
+let file = lazy (find ())
 
 let read f ~default =
   Lazy.force file >>| function

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name dune_release)
  (public_name dune-release)
- (libraries fmt bos curly opam-state rresult bos.setup yaml yojson))
+ (libraries fmt bos curly opam-state rresult bos.setup yojson))

--- a/lib/stdext.ml
+++ b/lib/stdext.ml
@@ -66,8 +66,6 @@ module Option = struct
 
   let value ~default opt = match opt with Some x -> x | None -> default
 
-  let to_result ~none = function None -> Error none | Some x -> Ok x
-
   module O = struct
     let ( >>= ) opt f = bind ~f opt
 

--- a/lib/stdext.mli
+++ b/lib/stdext.mli
@@ -51,8 +51,6 @@ module Option : sig
 
   val value : default:'a -> 'a option -> 'a
 
-  val to_result : none:'e -> 'a option -> ('a, 'e) result
-
   module O : sig
     val ( >>= ) : 'a option -> ('a -> 'b option) -> 'b option
 


### PR DESCRIPTION
We concluded that YAML support is not something that we want to have since nobody actually likes the YAML format and creating a YAML parser is sufficiently difficult that the only good library for it uses ctypes to bind to libyaml. A more realistic alternative is switching the configuration to use s-expressions and use a proper s-expression parser in the medium term since we will need this to parse `dune-project` files anyway and this way we avoid the proliferation of various ad-hoc config files in the OCaml ecosystem.

This reverts commit 901a95402dc534b1cd067d51b68ffb1f64406aa6, reversing changes made to cee97c1235aadacd24474d798f4ba2ee6e1a4d0e.