### PR TITLE
Use the VCS tag instead of the version to create releases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 - Infer release versions are inferred from VCS tags. This change allows using
   `dune-release` on projects that do not use the changelog or have it in a
   different format.  (#381, #383 @Leonidas-from-XIV)
+- Fix a bug where `dune-release` couldn't retrieve a release on GitHub if the
+  tag and project version don't match (e.g. `v1.0` vs `1.0`). `dune-release`
+  would in such case believe the release doesn't exist, attempt to create it
+  and subsequently fail. (#387, #395, @Leonidas-from-XIV)
 
 ### Removed
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -413,14 +413,14 @@ let push_tag ~dry_run ~yes ~dev_repo vcs tag =
              command again"
             e)
 
-let curl_get_release ~dry_run ~token ~version ~user ~repo =
-  let curl_t = Github_v3_api.Release.Request.get ~version ~user ~repo in
+let curl_get_release ~dry_run ~token ~tag ~user ~repo =
+  let curl_t = Github_v3_api.Release.Request.get ~tag ~user ~repo in
   let curl_t = Github_v3_api.with_auth ~token curl_t in
   run_with_auth ~dry_run curl_t >>= Github_v3_api.Release.Response.release_id
 
 let create_release ~dry_run ~yes ~dev_repo ~token ~msg ~tag ~version ~user ~repo
     ~draft =
-  match curl_get_release ~dry_run ~token ~version ~user ~repo with
+  match curl_get_release ~dry_run ~token ~tag ~user ~repo with
   | Error _ ->
       Prompt.(
         confirm_or_abort ~yes

--- a/lib/github_v3_api.ml
+++ b/lib/github_v3_api.ml
@@ -54,11 +54,10 @@ let with_auth ~token Curl.{ url; meth; args } =
 
 module Release = struct
   module Request = struct
-    let get ~version ~user ~repo =
-      (* TODO: this should probably use `tag` and not `version` *)
+    let get ~tag ~user ~repo =
       let url =
         strf "https://api.github.com/repos/%s/%s/releases/tags/%a" user repo
-          Version.pp version
+          Vcs.Tag.pp tag
       in
       let args =
         let open Curl_option in

--- a/lib/github_v3_api.mli
+++ b/lib/github_v3_api.mli
@@ -4,7 +4,7 @@ val with_auth : token:string -> Curl.t -> Curl.t
 
 module Release : sig
   module Request : sig
-    val get : version:Version.t -> user:string -> repo:string -> Curl.t
+    val get : tag:Vcs.Tag.t -> user:string -> repo:string -> Curl.t
 
     val create :
       version:Version.t ->


### PR DESCRIPTION
After we implemented #386 to distinguish between a project version and a VCS tag it became pretty clear that the github release logic was using the wrong one. This PR uses the tag now.

Or in [meme form](https://twitter.com/godtributes): TAGS FOR THE TAG GOD