### PR TITLE
Add dependency to `opam-file-format`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,9 +33,9 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   (re (>= 1.7.2))
   astring
   (opam-file-format (>= 2.1.2))
-  (opam-format (>= 2.1.0~beta))
-  (opam-state (>= 2.1.0~beta))
-  (opam-core (>= 2.1.0~beta))
+  (opam-format (>= 2.1.0))
+  (opam-state (>= 2.1.0))
+  (opam-core (>= 2.1.0))
   rresult
   logs
   odoc

--- a/dune-project
+++ b/dune-project
@@ -32,6 +32,7 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   cmdliner
   (re (>= 1.7.2))
   astring
+  (opam-file-format (>= 2.1.2))
   (opam-format (>= 2.1.0~beta))
   (opam-state (>= 2.1.0~beta))
   (opam-core (>= 2.1.0~beta))

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -28,9 +28,9 @@ depends: [
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}
-  "opam-format" {>= "2.1.0~beta"}
-  "opam-state" {>= "2.1.0~beta"}
-  "opam-core" {>= "2.1.0~beta"}
+  "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-core" {>= "2.1.0"}
   "rresult"
   "logs"
   "odoc"

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -27,6 +27,7 @@ depends: [
   "cmdliner"
   "re" {>= "1.7.2"}
   "astring"
+  "opam-file-format" {>= "2.1.2"}
   "opam-format" {>= "2.1.0~beta"}
   "opam-state" {>= "2.1.0~beta"}
   "opam-core" {>= "2.1.0~beta"}

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,5 @@
 (library
  (name dune_release)
  (public_name dune-release)
- (libraries fmt fpath bos curly opam-state rresult bos.setup yojson))
+ (libraries fmt fpath bos curly opam-state rresult bos.setup yojson
+   opam-file-format))


### PR DESCRIPTION
The module `OpamParserTypes.FullPos` is from ocaml-file-format and if too low of a version is selected ([like `2.0.0~rc2` by the OCaml CI](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b6acd886778d49581c876692880f381ddd813cd0/variant/opam-2.1,compilers,4.06,dune-release.1.5.2,lower-bounds)) as a dependency of `opam-format` then the build will fail.

Therefore we need `opam-file-format` as direct dependency.