### PR TITLE
tests: ensure user.email and user.name is always set to allow commiting

### DIFF
--- a/tests/bin/opam-pkg-distrib-multiple/run.t
+++ b/tests/bin/opam-pkg-distrib-multiple/run.t
@@ -33,6 +33,8 @@ Set up a project with two opam packages
 Set up a git project for dune-release to work properly
 
   $ git init 2> /dev/null > /dev/null
+  $ git config user.name "dune-release-test"
+  $ git config user.email "pseudo@pseudo.invalid"
   $ git add CHANGES.md whatever.opam whatever-sub.opam dune-project .gitignore
   $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/version-from-tag/run.t
+++ b/tests/bin/version-from-tag/run.t
@@ -28,6 +28,8 @@ We need a basic opam project skeleton
 We need to set up a git project with two commits to test trying to tag different commits with the same tag name.
 
   $ git init 2> /dev/null > /dev/null
+  $ git config user.name "dune-release-test"
+  $ git config user.email "pseudo@pseudo.invalid"
   $ git add whatever.opam dune-project .gitignore CHANGES.md README.md LICENSE
   $ git commit -m "Testing" --quiet
 


### PR DESCRIPTION
Similar regression as also fixed in #334: We need to ensure that the git user's name and email are set, otherwise we can't create a commit if no global git configuration has been set up.