### PR TITLE
Parse change logs in the style of keepachangelog.com

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,15 +4,14 @@
 
 - Add `--skip-lint`, `--skip-build`, `--skip-test` and
   `--keep-build-dir` to the main command (#419, @NathanReb)
+- Added support for parsing changelogs written in the style of
+  [keepachangelog.com](https://keepachangelog.com/) (#421, @ifazk)
 
 ### Changed
 
 ### Deprecated
 
 ### Fixed
-
-- Fixed parsing the changelog if it is written in the style of
-  keepachangelog.com(https://keepachangelog.com/) (#421, @ifazk)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 ### Fixed
 
 - Fixed parsing the changelog if it is written in the style of
-  keepachangelog.com(https://keepachangelog.com/) (#<PR_NUMBER>, @ifazk)
+  keepachangelog.com(https://keepachangelog.com/) (#421, @ifazk)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ### Fixed
 
+- Fixed parsing the changelog if it is written in the style of
+  keepachangelog.com(https://keepachangelog.com/) (#<PR_NUMBER>, @ifazk)
+
 ### Removed
 
 ### Security

--- a/lib/text.ml
+++ b/lib/text.ml
@@ -123,15 +123,9 @@ let rec change_log_last_entry ?flavour text =
               | "" :: lines -> String.concat ~sep:"\n" lines
               | lines -> String.concat ~sep:"\n" lines
             in
-            let version =
-              let fst = String.get version 0 in
-              let len = String.length version in
-              let last = String.(get version (len - 1)) in
-              if List.mem fst [ '('; '[' ] && List.mem last [ ')'; ']' ] then
-                (* Drop delimitors for keepachangelog.com style *)
-                String.with_index_range ~first:1 ~last:(len - 2) version
-              else version
-            in
+            (* Drop delimitors from version, useful for keepachangelog.com style *)
+            let version_delimitors = function '[' | ']' | '(' | ')' -> true | _ -> false in
+            let version = String.trim ~drop:version_delimitors version in
             Some (Version.Changelog.of_string version, (h, changes)))
 
 let change_log_file_last_entry file =

--- a/lib/text.ml
+++ b/lib/text.ml
@@ -124,7 +124,10 @@ let rec change_log_last_entry ?flavour text =
               | lines -> String.concat ~sep:"\n" lines
             in
             (* Drop delimitors from version, useful for keepachangelog.com style *)
-            let version_delimitors = function '[' | ']' | '(' | ')' -> true | _ -> false in
+            let version_delimitors = function
+              | '[' | ']' | '(' | ')' -> true
+              | _ -> false
+            in
             let version = String.trim ~drop:version_delimitors version in
             Some (Version.Changelog.of_string version, (h, changes)))
 

--- a/tests/lib/test_text.ml
+++ b/tests/lib/test_text.ml
@@ -48,6 +48,68 @@ change A
 change B
 |}
       ~expected:(Some (ch "v0.1", ("# v0.1", "change A")));
+    make_test ~name:"keepachangelog.com 1"
+      ~input:
+        {|
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-12-26
+### Added
+- Added 3
+- Added 2
+
+### Changed
+- Changed 1
+
+### Removed
+- Removed 1
+
+## [0.3.0] - 2021-12-03
+### Added
+- Added 1
+|}
+      ~expected:(Some (ch "Unreleased", ("## [Unreleased]", "")));
+    make_test ~name:"keepachangelog.com 2"
+      ~input:
+        {|
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2021-12-26
+### Added
+- Added 3
+- Added 2
+
+### Changed
+- Changed 1
+
+### Removed
+- Removed 1
+
+## [0.3.0] - 2021-12-03
+### Added
+- Added 1
+|}
+      ~expected:
+        (Some
+           ( ch "1.0.0",
+             ( "## [1.0.0] - 2021-12-26",
+               "### Added\n\
+                - Added 3\n\
+                - Added 2\n\n\
+                ### Changed\n\
+                - Changed 1\n\n\
+                ### Removed\n\
+                - Removed 1" ) ));
   ]
 
 let test_rewrite_github_refs =


### PR DESCRIPTION
I recently started using the change log format specified in https://keepachangelog.com. This format uses "Changelog" as the first level of header.

This resulted in `dune-release` trying to use `"Changelog"` as the tag. I manually specified the tag, but then `dune-release` used the entire changelog for the pull-request message, see https://github.com/ocaml/opam-repository/pull/20195.

This PR changes `Text.change_log_last_entry` to recurse into `changes` if the header title is "Changelog", and drops brackets around version numbers if there are any.

Btw, I wasn't sure if PRs from outsiders are welcome or not and I didn't find a contribution guide. Hope this doesn't feel too aggressive since I didn't open an issue first.