### PR TITLE
RFC: Rely on the remote URL to get the main package name

### DIFF
--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -15,7 +15,7 @@ type t
 
 val infer_name_err : ('a, Format.formatter, unit, unit, unit, 'a) format6
 
-val try_infer_name : Fpath.t -> (string option, [> Rresult.R.msg ]) result
+val try_infer_name : Fpath.t -> (string option, R.msg) result
 (** [try_infer_name dir] tries to infer the name of the main package in [dir].
     If you already have a package [p], use [name p] instead. *)
 

--- a/lib/uri_helpers.ml
+++ b/lib/uri_helpers.ml
@@ -64,3 +64,6 @@ let append_to_base ~rel_path base =
 
 let chop_git_prefix uri =
   match String.cut ~sep:"git+" uri with Some ("", rest) -> rest | _ -> uri
+
+let chop_git_suffix uri =
+  match Filename.chop_suffix_opt ~suffix:".git" uri with Some x -> x | _ -> uri

--- a/lib/uri_helpers.mli
+++ b/lib/uri_helpers.mli
@@ -23,3 +23,6 @@ val append_to_base : rel_path:string -> string -> string
 
 val chop_git_prefix : string -> string
 (** Chop the prefix [git+] from a URI, if any. *)
+
+val chop_git_suffix : string -> string
+(** Chop the suffix [.git] from a URI, if any. *)

--- a/lib/vcs.ml
+++ b/lib/vcs.ml
@@ -146,6 +146,10 @@ let git_branch_exists ~dry_run r br =
   in
   match run_git_quiet ~dry_run r cmd with Ok () -> true | _ -> false
 
+let git_remote_url r =
+  run_git_string ~dry_run:false r ~default:Default.string
+    Cmd.(v "config" % "--get" % "remote.origin.url")
+
 let git_clone ~dry_run ?force ?branch ~dir:d r =
   let branch =
     match branch with None -> Cmd.empty | Some b -> Cmd.(v "-b" % b)
@@ -274,6 +278,9 @@ let hg_describe ~dirty r ~rev =
       hg_id ~rev:"tip" r >>= fun (_, is_dirty) ->
       Ok (if is_dirty then dirtify descr else descr)
 
+let hg_remote_url r =
+  run_hg r Cmd.(v "paths" % "default") OS.Cmd.out_string
+
 (* hg order is reverse from git *)
 
 let hg_clone r ~dir:d =
@@ -366,6 +373,11 @@ let branch_exists ~dry_run r tag =
   match r with
   | (`Git, _, _) as r -> git_branch_exists r ~dry_run tag
   | `Hg, _, _ -> failwith "TODO"
+
+let remote_url r =
+  match r with
+  | `Git, _, _ -> git_remote_url r
+  | `Hg, _, _ -> hg_remote_url r
 
 (* Operations *)
 

--- a/lib/vcs.mli
+++ b/lib/vcs.mli
@@ -92,6 +92,7 @@ val get_tag : t -> (Tag.t, R.msg) result
 val tag_exists : dry_run:bool -> t -> Tag.t -> bool
 val tag_points_to : t -> Tag.t -> string option
 val branch_exists : dry_run:bool -> t -> commit_ish -> bool
+val remote_url : t -> (string, R.msg) result
 
 (** {1:ops Repository operations} *)
 

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -24,6 +24,7 @@ Make a minimal project set up
   > (lang dune 2.7)
   > (name my_pkg)
   > EOF
+  $ git config remote.origin.url git+https://github.com/fu/fa.git
 
 If the condition described above is fulfilled, there are 4 checks to be performed
 
@@ -194,6 +195,7 @@ but not dune-release compatible on the last git tag.
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add my_pkg.opam
   $ git commit -m "Initial commit" > /dev/null
   $ git tag -a 0.1.0 HEAD -m "release 0.1.0"

--- a/tests/bin/delegate-info/run.t
+++ b/tests/bin/delegate-info/run.t
@@ -20,6 +20,7 @@ We need to set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/distrib-name/run.t
+++ b/tests/bin/distrib-name/run.t
@@ -48,9 +48,9 @@ dune-release distrib --dry-run with no project name should fail as well.
 Add an uncommitted name to dune-project. (Because of a dune limitation
 this name must be one the .opam file names.)
 
-  $ echo "(name liba)" >> dune-project
+  $ git config remote.origin.url git+https://github.com/foo/liba.git
 
-Run dune-release distrib with the uncomitted name in dune-project.
+Run dune-release distrib with the name set in git config.
 
   $ dune-release tag -y > /dev/null
   $ dune-release distrib --skip-lint > /dev/null
@@ -64,7 +64,6 @@ Run dune-release distrib with the uncomitted name in dune-project.
 
 Commit the change in dune-project and run distrib.
 
-  $ git add dune-project && git commit -m 'add name' > /dev/null
   $ dune-release distrib --skip-lint | make_dune_release_deterministic
   [-] Building source archive
   [+] Wrote archive _build/liba-0.42.0-1-<deterministic>.tbz

--- a/tests/bin/draft/run.t
+++ b/tests/bin/draft/run.t
@@ -32,6 +32,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/errors/run.t
+++ b/tests/bin/errors/run.t
@@ -20,6 +20,7 @@ We need to set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project
   $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/include-submodules/run.t
+++ b/tests/bin/include-submodules/run.t
@@ -24,6 +24,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/include-versioned-dotfiles/run.t
+++ b/tests/bin/include-versioned-dotfiles/run.t
@@ -29,6 +29,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project .somedotfile .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/invalid-version-number/run.t
+++ b/tests/bin/invalid-version-number/run.t
@@ -32,6 +32,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/no-doc/run.t
+++ b/tests/bin/no-doc/run.t
@@ -35,6 +35,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam whatever-lib.opam dune-project README LICENSE
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/non-github-doc-uri/run.t
+++ b/tests/bin/non-github-doc-uri/run.t
@@ -35,6 +35,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/non-github-uri/run.t
+++ b/tests/bin/non-github-uri/run.t
@@ -36,6 +36,7 @@ We need to set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y

--- a/tests/bin/opam-pkg-distrib-file-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-file-opt/run.t
@@ -22,6 +22,7 @@ We need to set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project
   $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/opam-pkg-distrib-multiple/run.t
+++ b/tests/bin/opam-pkg-distrib-multiple/run.t
@@ -35,6 +35,7 @@ Set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam whatever-sub.opam dune-project .gitignore
   $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/opam-pkg-distrib-uri-opt/run.t
+++ b/tests/bin/opam-pkg-distrib-uri-opt/run.t
@@ -22,6 +22,7 @@ We need to set up a git project for dune-release to work properly
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project
   $ git commit -m "Initial commit" > /dev/null
 

--- a/tests/bin/tag-2-packages/run.t
+++ b/tests/bin/tag-2-packages/run.t
@@ -1,4 +1,4 @@
-Set up a project with two packaged libraries, no name in `dune-project`.
+Set up a project with two packaged libraries, no name in git configuration.
 
   $ mkdir liba libb
   $ cat > CHANGES.md << EOF
@@ -25,8 +25,9 @@ Expect an error message about the name in `dune-project`.
   dune-release: [ERROR] cannot determine distribution name automatically: add (name <name>) to dune-project
   [1]
 
-Use `(name <name>)` in `dune-project` (not committed).
+Use remote url in git config.
 
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ cat > CHANGES.md << EOF
   > ## 0.44.0
   > 

--- a/tests/bin/tag/run.t
+++ b/tests/bin/tag/run.t
@@ -21,6 +21,7 @@ We need to set up a git project with two commits to test trying to tag different
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add whatever.opam dune-project
   $ git commit -m "Initial commit" > /dev/null
   $ git add CHANGES.md

--- a/tests/bin/url-file/run.t
+++ b/tests/bin/url-file/run.t
@@ -32,6 +32,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null

--- a/tests/bin/version-from-tag/run.t
+++ b/tests/bin/version-from-tag/run.t
@@ -30,6 +30,7 @@ We need to set up a git project with two commits to test trying to tag different
   $ git init 2> /dev/null > /dev/null
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add whatever.opam dune-project .gitignore CHANGES.md README.md LICENSE
   $ git commit -m "Testing" --quiet
 

--- a/tests/bin/x-commit-hash/run.t
+++ b/tests/bin/x-commit-hash/run.t
@@ -33,6 +33,7 @@ We need to set up a git project for dune-release to work properly
   $ git init > /dev/null 2>&1
   $ git config user.name "dune-release-test"
   $ git config user.email "pseudo@pseudo.invalid"
+  $ git config remote.origin.url git+https://github.com/foo/whatever.git
   $ git add CHANGES.md whatever.opam dune-project README LICENSE .gitignore
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null


### PR DESCRIPTION
Based on the discussion in #366

The idea is to not check the dune-project file and the opam files as it is currently incorrect, but rely on git remote URL instead. Asking for some feedback before going further with this PR. (yeah it somehow overwrites the local config, will look into it if you like the idea)

PS: I'm doing this because releasing ocamlformat is painful because of this issue.