### PR TITLE
Improve `distrib` dirty repo warning message

### DIFF
--- a/bin/distrib.ml
+++ b/bin/distrib.ml
@@ -21,8 +21,8 @@ let check_archive ~dry_run ~skip_lint ~skip_build ~skip_tests ~pkg_names pkg ar
 
 let warn_if_vcs_dirty () =
   Cli.warn_if_vcs_dirty
-    ("The distribution archive may be inconsistent."
-   ^ " Uncommitted changes to files (including dune-project) will be ignored.")
+    "Uncommitted changes to files (including dune-project) will not be \
+     included in the distribution archive."
 
 let log_footprint pkg archive =
   Pkg.name pkg >>= fun name ->

--- a/tests/bin/distrib-name/run.t
+++ b/tests/bin/distrib-name/run.t
@@ -54,9 +54,9 @@ Run dune-release distrib with the uncomitted name in dune-project.
 
   $ dune-release tag -y > /dev/null
   $ dune-release distrib --skip-lint > /dev/null
-  dune-release: [WARNING] The repo is dirty. The distribution archive may be
-                          inconsistent. Uncommitted changes to files (including
-                          dune-project) will be ignored.
+  dune-release: [WARNING] The repo is dirty. Uncommitted changes to files
+                          (including dune-project) will not be included in the
+                          distribution archive.
   Error: The project name is not defined, please add a (name <name>) field to
   your dune-project file.
   dune-release: [ERROR] run ['dune' 'subst']: exited with 1


### PR DESCRIPTION
Fixes #443 

The message was a bit confusing and could lead people to believe those changes could end up in the archive whereas it was trying to warn them of the opposite.