### PR TITLE
Fix dune-project name parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 - Fix project name detection from `dune-project`. The parser could get confused
   when opam file generation is used. Now it only considers the first `(name X)`
-  in the file. (#<PR_NUMBER>, @emillon)
+  in the file. (#445, @emillon)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Fix project name detection from `dune-project`. The parser could get confused
+  when opam file generation is used. Now it only considers the first `(name X)`
+  in the file. (#<PR_NUMBER>, @emillon)
+
 ### Removed
 
 - Remove support for delegates.

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name dune_release)
  (public_name dune-release)
  (libraries fmt fpath bos curly opam-state rresult bos.setup yojson
-   opam-file-format))
+   opam-file-format re))

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -235,23 +235,21 @@ let publish_msg p =
       change_log p >>= Text.change_log_file_last_entry >>| fun (_, (_, txt)) ->
       strf "CHANGES:\n\n%s\n" txt
 
+let dune_project_name_string lines =
+  List.fold_left
+    (fun acc line ->
+      (* sorry *)
+      match String.cut ~sep:"(name " (String.trim line) with
+      | Some (_, s) ->
+          Some (String.trim ~drop:(function ')' | ' ' -> true | _ -> false) s)
+      | _ -> acc)
+    None lines
+
 let dune_project_name dir =
   let file = Fpath.(dir / "dune-project") in
   Bos.OS.File.exists file >>= function
   | false -> Ok None
-  | true ->
-      Bos.OS.File.read_lines file >>| fun lines ->
-      List.fold_left
-        (fun acc line ->
-          (* sorry *)
-          match String.cut ~sep:"(name " (String.trim line) with
-          | Some (_, s) ->
-              Some
-                (String.trim
-                   ~drop:(function ')' | ' ' -> true | _ -> false)
-                   s)
-          | _ -> acc)
-        None lines
+  | true -> Bos.OS.File.read_lines file >>| dune_project_name_string
 
 let infer_pkg_names dir = function
   | [] ->

--- a/lib/pkg.ml
+++ b/lib/pkg.ml
@@ -235,21 +235,29 @@ let publish_msg p =
       change_log p >>= Text.change_log_file_last_entry >>| fun (_, (_, txt)) ->
       strf "CHANGES:\n\n%s\n" txt
 
-let dune_project_name_string lines =
-  List.fold_left
-    (fun acc line ->
-      (* sorry *)
-      match String.cut ~sep:"(name " (String.trim line) with
-      | Some (_, s) ->
-          Some (String.trim ~drop:(function ')' | ' ' -> true | _ -> false) s)
-      | _ -> acc)
-    None lines
+let dune_project_name_string contents =
+  let opam_pkg_name_char = Re.(alt [ wordc; char '-' ]) in
+  let re =
+    Re.(
+      compile
+        (seq
+           [
+             str "(";
+             rep space;
+             str "name";
+             rep space;
+             group (rep opam_pkg_name_char);
+             rep space;
+             str ")";
+           ]))
+  in
+  Option.map (fun group -> Re.Group.get group 1) (Re.exec_opt re contents)
 
 let dune_project_name dir =
   let file = Fpath.(dir / "dune-project") in
   Bos.OS.File.exists file >>= function
   | false -> Ok None
-  | true -> Bos.OS.File.read_lines file >>| dune_project_name_string
+  | true -> Bos.OS.File.read file >>| dune_project_name_string
 
 let infer_pkg_names dir = function
   | [] ->

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -155,18 +155,18 @@ val version_of_changelog : t -> Version.Changelog.t -> Version.t
 val dev_repo : t -> (string option, Sos.error) result
 (** dev-repo field with the ["git+"] prefix removed. *)
 
+(** {1 Dune project} *)
+
+val dune_project_name : Fpath.t -> (string option, [> Rresult.R.msg ]) result
+(** Returns the name stanza entry of the dune project, if any; else, returns
+    `None`. Returns an error, if one of the system calls fails. *)
+
 (**/**)
 
 val version_line_re : Re.t
 
 val prepare_opam_for_distrib :
   version:Version.t -> content:string list -> string list
-
-(** {1 Dune project} *)
-
-val dune_project_name : Fpath.t -> (string option, [> Rresult.R.msg ]) result
-(** Returns the name stanza entry of the dune project, if any; else, returns
-    `None`. Returns an error, if one of the system calls fails. *)
 
 val dune_project_name_string : string -> string option
 

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -168,7 +168,7 @@ val dune_project_name : Fpath.t -> (string option, [> Rresult.R.msg ]) result
 (** Returns the name stanza entry of the dune project, if any; else, returns
     `None`. Returns an error, if one of the system calls fails. *)
 
-val dune_project_name_string : string list -> string option
+val dune_project_name_string : string -> string option
 
 (**/**)
 

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -168,6 +168,8 @@ val dune_project_name : Fpath.t -> (string option, [> Rresult.R.msg ]) result
 (** Returns the name stanza entry of the dune project, if any; else, returns
     `None`. Returns an error, if one of the system calls fails. *)
 
+val dune_project_name_string : string list -> string option
+
 (**/**)
 
 (*---------------------------------------------------------------------------

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -104,27 +104,31 @@ let distrib_uri =
   ]
 
 let test_dune_project_name =
-  let test ~name lines ~expected =
+  let test ~name contents ~expected =
     ( name,
       `Quick,
       fun () ->
-        let got = Pkg.dune_project_name_string lines in
+        let got = Pkg.dune_project_name_string contents in
         Alcotest.check Alcotest.(option string) __LOC__ expected got )
   in
+  let unlines l = String.concat "\n" l in
   [
-    test ~name:"ok" [ "(lang dune 2.4)"; "(name xyz)" ] ~expected:(Some "xyz");
-    test ~name:"no name" [ "(lang dune 2.4)" ] ~expected:None;
+    test ~name:"ok" "(lang dune 2.4)\n(name xyz)" ~expected:(Some "xyz");
+    test ~name:"no name" "(lang dune 2.4)" ~expected:None;
     test ~name:"opam file generation"
-      [
-        "(lang dune 2.7)";
-        "(name first)";
-        "(generate_opam_files true)";
-        "(package";
-        " (name first))";
-        "(package";
-        " (name second))";
-      ]
-      ~expected:(Some "second");
+      (unlines
+         [
+           "(lang dune 2.7)";
+           "(name first)";
+           "(generate_opam_files true)";
+           "(package";
+           " (name first))";
+           "(package";
+           " (name second))";
+         ])
+      ~expected:(Some "first");
+    test ~name:"leading whitespace" "(lang dune 2.4)\n (name xyz)"
+      ~expected:(Some "xyz");
   ]
 
 let suite =

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -103,7 +103,36 @@ let distrib_uri =
       ~tag:"v0" url;
   ]
 
+let test_dune_project_name =
+  let test ~name lines ~expected =
+    ( name,
+      `Quick,
+      fun () ->
+        let got = Pkg.dune_project_name_string lines in
+        Alcotest.check Alcotest.(option string) __LOC__ expected got )
+  in
+  [
+    test ~name:"ok" [ "(lang dune 2.4)"; "(name xyz)" ] ~expected:(Some "xyz");
+    test ~name:"no name" [ "(lang dune 2.4)" ] ~expected:None;
+    test ~name:"opam file generation"
+      [
+        "(lang dune 2.7)";
+        "(name first)";
+        "(generate_opam_files true)";
+        "(package";
+        " (name first))";
+        "(package";
+        " (name second))";
+      ]
+      ~expected:(Some "second");
+  ]
+
 let suite =
   ( "Pkg",
     List.concat
-      [ test_version_line_re; test_prepare_opam_for_distrib; distrib_uri ] )
+      [
+        test_version_line_re;
+        test_prepare_opam_for_distrib;
+        distrib_uri;
+        test_dune_project_name;
+      ] )


### PR DESCRIPTION
The current parsing code looks for `(name X)` on all lines of `dune-project`, and returns the last one that matches. This can return the wrong value when opam file generation is used, for example:

    (lang dune 2.4)
    (name main)
    (generate_opam_files true)

    (package
     (name main))

    (package
     (name other))

In this case, the project name is parsed as `other`.

This PR fixes it by only looking at the beginning of the line and returning the first match. It also uses `Re` (already used) instead of direct string manipulation.
